### PR TITLE
Nanboxing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1,9 +1,27 @@
 [[package]]
+name = "aho-corasick"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "memchr 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "allocator_api"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "atty"
+version = "0.2.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -81,7 +99,20 @@ dependencies = [
  "num-traits 0.2.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "once_cell 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "quickcheck 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.5.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
+ "humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -128,6 +159,19 @@ dependencies = [
  "byteorder 1.2.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "humantime"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "lazy_static"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "libc"
@@ -347,6 +391,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "quickcheck"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)",
+ "log 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rand_core 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rand"
 version = "0.3.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -468,6 +528,34 @@ version = "0.1.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "redox_termios"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "redox_syscall 0.1.50 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "memchr 2.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "regex-syntax 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
+ "thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "rustc-serialize"
 version = "0.3.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -512,6 +600,32 @@ version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "termcolor"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "termion"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_syscall 0.1.50 (registry+https://github.com/rust-lang/crates.io-index)",
+ "redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
+name = "thread_local"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "time"
 version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -520,6 +634,11 @@ dependencies = [
  "redox_syscall 0.1.50 (registry+https://github.com/rust-lang/crates.io-index)",
  "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "ucd-util"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "unicode-width"
@@ -533,6 +652,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "utf8-ranges"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "version_check"
@@ -559,12 +683,31 @@ version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "winapi-util"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
+[[package]]
+name = "wincolor"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
 [metadata]
+"checksum aho-corasick 0.6.9 (registry+https://github.com/rust-lang/crates.io-index)" = "1e9a933f4e58658d7b12defcf96dc5c720f20832deebe3e0a19efd3b6aaeeb9e"
 "checksum allocator_api 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)" = "4ad82210cfa8c0644bae46f1ddfbed61e68b1ebc89ac7a6bcee163bacb3de10a"
+"checksum atty 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)" = "9a7d5b8723950951411ee34d271d99dddcc2035a16ab25310ea2c8cfd4369652"
 "checksum autocfg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "4e5f34df7a019573fb8bdc7e24a2bfebe51a2a1d6bfdbaeccedb3c41fc574727"
 "checksum bitflags 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "228047a76f468627ca71776ecdebd732a3423081fcf5125585bcd7c49886ce12"
 "checksum byteorder 0.4.2 (registry+https://github.com/rust-lang/crates.io-index)" = "96c8b41881888cc08af32d47ac4edd52bc7fa27fef774be47a92443756451304"
@@ -573,12 +716,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum chrono 0.4.6 (registry+https://github.com/rust-lang/crates.io-index)" = "45912881121cb26fad7c38c17ba7daa18764771836b34fab7d3fbd93ed633878"
 "checksum cloudabi 0.0.3 (registry+https://github.com/rust-lang/crates.io-index)" = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 "checksum compress 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "b175f2657191d74b13d574c36ae58f598b1510d42df2b65e692347fdaf7a9268"
+"checksum env_logger 0.5.13 (registry+https://github.com/rust-lang/crates.io-index)" = "15b0a4d2e39f8420210be8b27eeda28029729e2fd4291019455016c348240c38"
 "checksum fnv 1.0.6 (registry+https://github.com/rust-lang/crates.io-index)" = "2fad85553e09a6f881f739c29f0b00b0f01357c743266d478b68951ce23285f3"
 "checksum fuchsia-zircon 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "2e9763c69ebaae630ba35f74888db465e49e259ba1bc0eda7d06f4a067615d82"
 "checksum fuchsia-zircon-sys 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 "checksum getopts 0.2.18 (registry+https://github.com/rust-lang/crates.io-index)" = "0a7292d30132fb5424b354f5dc02512a86e4c516fe544bb7a25e7f266951b797"
 "checksum hamt-rs 0.3.0 (git+https://github.com/michaelwoerister/hamt-rs/)" = "<none>"
 "checksum hashbrown 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)" = "64b7d419d0622ae02fe5da6b9a5e1964b610a65bb37923b976aeebb6dbb8f86e"
+"checksum humantime 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "3ca7e5f2e110db35f93b837c81797f3714500b81d517bf20c431b16d3ca4f114"
+"checksum lazy_static 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "a374c89b9db55895453a74c1e38861d9deec0b01b405a82516e9d5de4820dea1"
 "checksum libc 0.2.46 (registry+https://github.com/rust-lang/crates.io-index)" = "023a4cd09b2ff695f9734c1934145a315594b7986398496841c7031a5a1bbdbd"
 "checksum lock_api 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "62ebf1391f6acad60e5c8b43706dde4582df75c06698ab44511d15016bc2442c"
 "checksum log 0.3.9 (registry+https://github.com/rust-lang/crates.io-index)" = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
@@ -603,6 +749,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum parking_lot 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ab41b4aed082705d1056416ae4468b6ea99d52599ecf3169b00088d43113e337"
 "checksum parking_lot_core 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)" = "ad7f7e6ebdc79edff6fdcb87a55b620174f7a989e3eb31b65231f4af57f00b8c"
 "checksum parking_lot_core 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "94c8c7923936b28d546dfd14d4472eaf34c99b14e1c973a32b3e6d4eb04298c9"
+"checksum quick-error 1.2.2 (registry+https://github.com/rust-lang/crates.io-index)" = "9274b940887ce9addde99c4eee6b5c44cc494b182b97e73dc8ffdcb3397fd3f0"
+"checksum quickcheck 0.8.0 (registry+https://github.com/rust-lang/crates.io-index)" = "dd69f633f796e091acd9a53e093bf01745b2c10ba44d22ea788f5fcbb862b720"
 "checksum rand 0.3.22 (registry+https://github.com/rust-lang/crates.io-index)" = "15a732abf9d20f0ad8eeb6f909bf6868722d9a06e1e50802b6a70351f40b4eb1"
 "checksum rand 0.4.3 (registry+https://github.com/rust-lang/crates.io-index)" = "8356f47b32624fef5b3301c1be97e5944ecdd595409cc5da11d05f211db6cfbd"
 "checksum rand 0.5.5 (registry+https://github.com/rust-lang/crates.io-index)" = "e464cd887e869cddcae8792a4ee31d23c7edd516700695608f5b98c67ee0131c"
@@ -616,6 +764,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum rand_pcg 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "086bd09a33c7044e56bb44d5bdde5a60e7f119a9e95b0775f545de759a32fe05"
 "checksum rand_xorshift 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "cbf7e9e623549b0e21f6e97cf8ecf247c1a8fd2e8a992ae265314300b2455d5c"
 "checksum redox_syscall 0.1.50 (registry+https://github.com/rust-lang/crates.io-index)" = "52ee9a534dc1301776eff45b4fa92d2c39b1d8c3d3357e6eb593e0d795506fc2"
+"checksum redox_termios 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "7e891cfe48e9100a70a3b6eb652fef28920c117d366339687bd5576160db0f76"
+"checksum regex 1.1.0 (registry+https://github.com/rust-lang/crates.io-index)" = "37e7cbbd370869ce2e8dff25c7018702d10b21a20ef7135316f8daecd6c25b7f"
+"checksum regex-syntax 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4e47a2ed29da7a9e1960e1639e7a982e6edc6d49be308a3b02daf511504a16d1"
 "checksum rustc-serialize 0.3.24 (registry+https://github.com/rust-lang/crates.io-index)" = "dcf128d1287d2ea9d80910b5f1120d0b8eede3fbf1abe91c40d39ea7d51e6fda"
 "checksum rustc_version 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)" = "138e3e0acb6c9fb258b19b67cb8abd63c00679d2851805ea151465464fe9030a"
 "checksum scopeguard 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)" = "94258f53601af11e6a49f722422f6e3425c52b06245a5cf9bc09908b174f5e27"
@@ -623,11 +774,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 "checksum semver-parser 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)" = "388a1df253eca08550bef6c72392cfe7c30914bf41df5269b68cbd6ff8f570a3"
 "checksum smallvec 0.6.7 (registry+https://github.com/rust-lang/crates.io-index)" = "b73ea3738b47563803ef814925e69be00799a8c07420be8b996f8e98fb2336db"
 "checksum stable_deref_trait 1.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "dba1a27d3efae4351c8051072d619e3ade2820635c3958d826bfea39d59b54c8"
+"checksum termcolor 1.0.4 (registry+https://github.com/rust-lang/crates.io-index)" = "4096add70612622289f2fdcdbd5086dc81c1e2675e6ae58d6c4f62a16c6d7f2f"
+"checksum termion 1.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "689a3bdfaab439fd92bc87df5c4c78417d3cbe537487274e9b0b2dce76e92096"
+"checksum thread_local 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "c6b53e329000edc2b34dbe8545fd20e55a333362d0a321909685a19bd28c3f1b"
 "checksum time 0.1.41 (registry+https://github.com/rust-lang/crates.io-index)" = "847da467bf0db05882a9e2375934a8a55cffdc9db0d128af1518200260ba1f6c"
+"checksum ucd-util 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "535c204ee4d8434478593480b8f86ab45ec9aae0e83c568ca81abf0fd0e88f86"
 "checksum unicode-width 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "882386231c45df4700b275c7ff55b6f3698780a650026380e72dabe76fa46526"
 "checksum unreachable 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "382810877fe448991dfc7f0dd6e3ae5d58088fd0ea5e35189655f84e6814fa56"
+"checksum utf8-ranges 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "796f7e48bef87609f7ade7e06495a87d5cd06c7866e6a5cbfceffc558a243737"
 "checksum version_check 0.1.5 (registry+https://github.com/rust-lang/crates.io-index)" = "914b1a6776c4c929a602fafd8bc742e06365d4bcbe48c30f9cca5824f70dc9dd"
 "checksum void 1.0.2 (registry+https://github.com/rust-lang/crates.io-index)" = "6a02e4885ed3bc0f2de90ea6dd45ebcbb66dacffe03547fadbb0eeae2770887d"
 "checksum winapi 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)" = "92c1eb33641e276cfa214a0522acad57be5c56b10cb348b3c5117db75f3ac4b0"
 "checksum winapi-i686-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+"checksum winapi-util 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "afc5508759c5bf4285e61feb862b6083c8480aec864fa17a81fdec6f69b461ab"
 "checksum winapi-x86_64-pc-windows-gnu 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)" = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+"checksum wincolor 1.0.1 (registry+https://github.com/rust-lang/crates.io-index)" = "561ed901ae465d6185fa7864d63fbd5720d0ef718366c9a4dc83cf6170d7e9ba"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,5 +33,8 @@ log = "0.4"
 hashbrown = "0.1.7"
 nodrop = "0.1.13"
 
+[dev-dependencies]
+quickcheck = "0.8.0"
+
 # [profile.release]
 # debug = true

--- a/src/atom.rs
+++ b/src/atom.rs
@@ -1,5 +1,5 @@
 //use std::ptr;
-use crate::value::Value;
+use crate::value::Term;
 use hashbrown::HashMap;
 use once_cell::sync::Lazy;
 use parking_lot::RwLock;
@@ -87,7 +87,7 @@ impl AtomTable {
         self.register_atom(val)
     }
 
-    pub fn to_str(&self, a: &Value) -> Result<String, String> {
+    pub fn to_str(&self, a: &Term) -> Result<String, String> {
         if let Value::Atom(index) = a {
             if let Some(p) = self.lookup(a) {
                 return Ok(unsafe { (*p).name.clone() });
@@ -97,7 +97,7 @@ impl AtomTable {
         panic!("Value is not an atom!")
     }
 
-    pub fn lookup(&self, a: &Value) -> Option<*const Atom> {
+    pub fn lookup(&self, a: &Term) -> Option<*const Atom> {
         if let Value::Atom(index) = a {
             let index_r = self.index_r.read();
             if *index >= index_r.len() as u32 {
@@ -208,7 +208,7 @@ pub fn from_str(val: &str) -> u32 {
     ATOMS.from_str(val)
 }
 
-pub fn to_str(a: &Value) -> Result<String, String> {
+pub fn to_str(a: &Term) -> Result<String, String> {
     ATOMS.to_str(a)
 }
 

--- a/src/atom.rs
+++ b/src/atom.rs
@@ -1,5 +1,4 @@
 //use std::ptr;
-use crate::value::Term;
 use hashbrown::HashMap;
 use once_cell::sync::Lazy;
 use parking_lot::RwLock;
@@ -87,27 +86,7 @@ impl AtomTable {
         self.register_atom(val)
     }
 
-    pub fn to_str(&self, a: &Term) -> Result<String, String> {
-        if let Value::Atom(index) = a {
-            if let Some(p) = self.lookup(a) {
-                return Ok(unsafe { (*p).name.clone() });
-            }
-            return Err(format!("Atom does not exist: {}", index));
-        }
-        panic!("Value is not an atom!")
-    }
-
-    pub fn lookup(&self, a: &Term) -> Option<*const Atom> {
-        if let Value::Atom(index) = a {
-            let index_r = self.index_r.read();
-            if *index >= index_r.len() as u32 {
-                return None;
-            }
-            return Some(&index_r[*index as usize] as *const Atom);
-        }
-        panic!("Value is not an atom!")
-    }
-    pub fn lookup_index(&self, index: u32) -> Option<*const Atom> {
+    pub fn lookup(&self, index: u32) -> Option<*const Atom> {
         let index_r = self.index_r.read();
         if index >= index_r.len() as u32 {
             return None;
@@ -208,12 +187,8 @@ pub fn from_str(val: &str) -> u32 {
     ATOMS.from_str(val)
 }
 
-pub fn to_str(a: &Term) -> Result<String, String> {
-    ATOMS.to_str(a)
-}
-
-pub fn from_index(index: u32) -> Result<String, String> {
-    if let Some(p) = ATOMS.lookup_index(index) {
+pub fn to_str(index: u32) -> Result<String, String> {
+    if let Some(p) = ATOMS.to_str(index) {
         return Ok(unsafe { (*p).name.clone() });
     }
     Err(format!("Atom does not exist: {}", index))

--- a/src/atom.rs
+++ b/src/atom.rs
@@ -86,7 +86,7 @@ impl AtomTable {
         self.register_atom(val)
     }
 
-    pub fn lookup(&self, index: u32) -> Option<*const Atom> {
+    pub fn to_str(&self, index: u32) -> Option<*const Atom> {
         let index_r = self.index_r.read();
         if index >= index_r.len() as u32 {
             return None;

--- a/src/bif.rs
+++ b/src/bif.rs
@@ -844,11 +844,11 @@ mod tests {
         let mut vec = Vec::new();
         let mut cons = &value;
         while let Ok(Cons { head, tail }) = cons.try_into() {
-            vec.push(head);
+            vec.push(*head);
             cons = &tail;
         }
         // lastly, the tail
-        vec.push((*cons).clone());
+        vec.push(*cons);
         vec
     }
 

--- a/src/bif.rs
+++ b/src/bif.rs
@@ -5,7 +5,7 @@ use crate::bitstring;
 use crate::numeric::division::{FlooredDiv, OverflowingFlooredDiv};
 use crate::numeric::modulo::{Modulo, OverflowingModulo};
 use crate::process::{self, RcProcess};
-use crate::value::{self, Value};
+use crate::value::{self, Term};
 use crate::vm;
 use crate::bif;
 use crate::servo_arc::Arc;
@@ -23,8 +23,8 @@ mod map;
 
 // maybe use https://github.com/sfackler/rust-phf
 
-type BifResult = Result<Value, Exception>;
-pub type BifFn = fn(&vm::Machine, &RcProcess, &[Value]) -> BifResult;
+type BifResult = Result<Term, Exception>;
+pub type BifFn = fn(&vm::Machine, &RcProcess, &[Term]) -> BifResult;
 type BifTable = HashMap<(u32, u32, u32), BifFn>;
 
 pub static BIFS: Lazy<BifTable> = sync_lazy! {
@@ -135,7 +135,7 @@ pub fn apply(
     vm: &vm::Machine,
     process: &RcProcess,
     mfa: &module::MFA,
-    args: &[Value],
+    args: &[Term],
 ) -> BifResult {
     (BIFS.get(mfa).unwrap())(vm, process, args)
 }
@@ -153,7 +153,7 @@ pub fn apply(
 //     .collect();
 
 /// Bif implementations
-fn bif_erlang_spawn_3(vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_erlang_spawn_3(vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     // parent: TODO: track parent of process
     // arg[0] = atom for module
     // arg[1] = atom for function
@@ -169,7 +169,7 @@ fn bif_erlang_spawn_3(vm: &vm::Machine, _process: &RcProcess, args: &[Value]) ->
     Err(Exception::new(Reason::EXC_BADARG))
 }
 
-fn bif_erlang_abs_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_erlang_abs_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     match &args[0] {
         Value::Integer(i) => Ok(Value::Integer(i.abs())),
         Value::Float(value::Float(f)) => Ok(Value::Float(value::Float(f.abs()))),
@@ -178,19 +178,19 @@ fn bif_erlang_abs_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> 
     }
 }
 
-fn bif_erlang_add_2(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_erlang_add_2(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     Ok(integer_overflow_op!(None, args, add, overflowing_add))
 }
 
-fn bif_erlang_sub_2(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_erlang_sub_2(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     Ok(integer_overflow_op!(None, args, sub, overflowing_sub))
 }
 
-fn bif_erlang_mult_2(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_erlang_mult_2(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     Ok(integer_overflow_op!(None, args, mul, overflowing_mul))
 }
 
-fn bif_erlang_intdiv_2(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_erlang_intdiv_2(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     Ok(integer_overflow_op!(
         None,
         args,
@@ -199,16 +199,16 @@ fn bif_erlang_intdiv_2(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) 
     ))
 }
 
-fn bif_erlang_mod_2(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_erlang_mod_2(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     // TODO: should be rem but it's mod
     Ok(integer_overflow_op!(None, args, modulo, overflowing_modulo))
 }
 
-fn bif_erlang_self_0(_vm: &vm::Machine, process: &RcProcess, _args: &[Value]) -> BifResult {
+fn bif_erlang_self_0(_vm: &vm::Machine, process: &RcProcess, _args: &[Term]) -> BifResult {
     Ok(Value::Pid(process.pid))
 }
 
-fn bif_erlang_send_2(vm: &vm::Machine, process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_erlang_send_2(vm: &vm::Machine, process: &RcProcess, args: &[Term]) -> BifResult {
     // args: dest <pid>, msg <term>
     let pid = &args[0];
     let msg = &args[1];
@@ -218,54 +218,54 @@ fn bif_erlang_send_2(vm: &vm::Machine, process: &RcProcess, args: &[Value]) -> B
     Ok(res)
 }
 
-fn bif_erlang_is_atom_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
-    Ok(Value::boolean(args[0].is_atom()))
+fn bif_erlang_is_atom_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
+    Ok(Term::boolean(args[0].is_atom()))
 }
 
-fn bif_erlang_is_list_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
-    Ok(Value::boolean(args[0].is_list()))
+fn bif_erlang_is_list_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
+    Ok(Term::boolean(args[0].is_list()))
 }
 
-fn bif_erlang_is_tuple_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
-    Ok(Value::boolean(args[0].is_tuple()))
+fn bif_erlang_is_tuple_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
+    Ok(Term::boolean(args[0].is_tuple()))
 }
 
-fn bif_erlang_is_float_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
-    Ok(Value::boolean(args[0].is_float()))
+fn bif_erlang_is_float_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
+    Ok(Term::boolean(args[0].is_float()))
 }
 
-fn bif_erlang_is_integer_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
-    Ok(Value::boolean(args[0].is_integer()))
+fn bif_erlang_is_integer_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
+    Ok(Term::boolean(args[0].is_integer()))
 }
 
-fn bif_erlang_is_number_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
-    Ok(Value::boolean(args[0].is_number()))
+fn bif_erlang_is_number_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
+    Ok(Term::boolean(args[0].is_number()))
 }
 
-fn bif_erlang_is_port_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
-    Ok(Value::boolean(args[0].is_port()))
+fn bif_erlang_is_port_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
+    Ok(Term::boolean(args[0].is_port()))
 }
 
-fn bif_erlang_is_reference_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
-    Ok(Value::boolean(args[0].is_ref()))
+fn bif_erlang_is_reference_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
+    Ok(Term::boolean(args[0].is_ref()))
 }
 
-fn bif_erlang_is_binary_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
-    Ok(Value::boolean(args[0].is_binary()))
+fn bif_erlang_is_binary_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
+    Ok(Term::boolean(args[0].is_binary()))
 }
 
-fn bif_erlang_is_function_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
-    Ok(Value::boolean(args[0].is_function()))
+fn bif_erlang_is_function_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
+    Ok(Term::boolean(args[0].is_function()))
 }
 
 // TODO: is_function_2, is_record
 
-fn bif_erlang_is_boolean_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
-    Ok(Value::boolean(args[0].is_boolean()))
+fn bif_erlang_is_boolean_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
+    Ok(Term::boolean(args[0].is_boolean()))
 }
 
-fn bif_erlang_is_map_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
-    Ok(Value::boolean(args[0].is_map()))
+fn bif_erlang_is_map_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
+    Ok(Term::boolean(args[0].is_map()))
 }
 
 macro_rules! trig_func {
@@ -283,71 +283,71 @@ macro_rules! trig_func {
     }};
 }
 
-fn bif_math_cos_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_math_cos_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     trig_func!(args[0], cos)
 }
 
-fn bif_math_cosh_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_math_cosh_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     trig_func!(args[0], cosh)
 }
 
-fn bif_math_sin_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_math_sin_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     trig_func!(args[0], sin)
 }
 
-fn bif_math_sinh_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_math_sinh_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     trig_func!(args[0], sinh)
 }
 
-fn bif_math_tan_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_math_tan_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     trig_func!(args[0], tan)
 }
 
-fn bif_math_tanh_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_math_tanh_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     trig_func!(args[0], tanh)
 }
 
-fn bif_math_acos_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_math_acos_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     trig_func!(args[0], acos)
 }
 
-fn bif_math_acosh_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_math_acosh_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     trig_func!(args[0], acosh)
 }
 
-fn bif_math_asin_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_math_asin_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     trig_func!(args[0], asin)
 }
 
-fn bif_math_asinh_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_math_asinh_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     trig_func!(args[0], asinh)
 }
 
-fn bif_math_atan_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_math_atan_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     trig_func!(args[0], atan)
 }
 
-fn bif_math_atanh_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_math_atanh_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     trig_func!(args[0], atanh)
 }
 
-fn bif_math_log_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_math_log_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     trig_func!(args[0], ln)
 }
 
-fn bif_math_log2_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_math_log2_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     trig_func!(args[0], log2)
 }
 
-fn bif_math_log10_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_math_log10_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     trig_func!(args[0], log10)
 }
 
-fn bif_math_sqrt_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_math_sqrt_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     trig_func!(args[0], sqrt)
 }
 
-fn bif_math_atan2_2(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_math_atan2_2(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     let res = match args[0] {
         Value::Integer(i) => i as f64, // TODO: potentially unsafe
         Value::Float(value::Float(f)) => f,
@@ -363,35 +363,35 @@ fn bif_math_atan2_2(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> 
     Ok(Value::Float(value::Float(res.atan2(arg))))
 }
 
-fn bif_erlang_tuple_size_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_erlang_tuple_size_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     let res = match &args[0] {
         Value::Tuple(t) => unsafe { (**t).len },
         _ => return Err(Exception::new(Reason::EXC_BADARG)),
     };
-    Ok(Value::Integer(res as i64))
+    Ok(Term::int(res as i32))
 }
 
-fn bif_erlang_byte_size_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_erlang_byte_size_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     let res = match &args[0] {
         Value::Binary(str) => str.data.len(),
         _ => return Err(Exception::new(Reason::EXC_BADARG)),
     };
-    Ok(Value::Integer(res as i64)) // TODO: cast potentially unsafe
+    Ok(Term::int(res as i32)) // TODO: cast potentially unsafe
 }
 
-fn bif_erlang_throw_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_erlang_throw_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     Err(Exception::with_value(Reason::EXC_THROWN, args[0].clone()))
 }
 
-fn bif_erlang_exit_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_erlang_exit_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     Err(Exception::with_value(Reason::EXC_EXIT, args[0].clone()))
 }
 
-fn bif_erlang_error_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_erlang_error_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     Err(Exception::with_value(Reason::EXC_ERROR, args[0].clone()))
 }
 
-fn bif_erlang_error_2(_vm: &vm::Machine, process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_erlang_error_2(_vm: &vm::Machine, process: &RcProcess, args: &[Term]) -> BifResult {
     let heap = &process.context_mut().heap;
 
     Err(Exception::with_value(
@@ -400,11 +400,11 @@ fn bif_erlang_error_2(_vm: &vm::Machine, process: &RcProcess, args: &[Value]) ->
     ))
 }
 
-fn bif_erlang_nif_error_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_erlang_nif_error_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     Err(Exception::with_value(Reason::EXC_ERROR, args[0].clone()))
 }
 
-fn bif_erlang_nif_error_2(_vm: &vm::Machine, process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_erlang_nif_error_2(_vm: &vm::Machine, process: &RcProcess, args: &[Term]) -> BifResult {
     let heap = &process.context_mut().heap;
 
     Err(Exception::with_value(
@@ -413,20 +413,20 @@ fn bif_erlang_nif_error_2(_vm: &vm::Machine, process: &RcProcess, args: &[Value]
     ))
 }
 
-fn bif_erlang_load_nif_2(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_erlang_load_nif_2(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     println!("Tried loading nif: {} with args {}", args[0], args[1]);
 
-    Ok(Value::Atom(atom::OK))
+    Ok(Term::atom(atom::OK))
 }
 
-pub fn bif_erlang_apply_2(_vm: &vm::Machine, _process: &RcProcess, _args: &[Value]) -> BifResult {
+pub fn bif_erlang_apply_2(_vm: &vm::Machine, _process: &RcProcess, _args: &[Term]) -> BifResult {
     // fun (closure), args
     // maps to i_apply_fun
 
     unreachable!("apply/2 called without macro override")
 }
 
-pub fn bif_erlang_apply_3(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+pub fn bif_erlang_apply_3(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     // module, function (atom), args
     unreachable!("apply/3 called without macro override");
     println!(
@@ -440,39 +440,39 @@ pub fn bif_erlang_apply_3(_vm: &vm::Machine, _process: &RcProcess, args: &[Value
 }
 
 /// this sets some process info- trapping exits or the error handler
-pub fn bif_erlang_process_flag_2(_vm: &vm::Machine, process: &RcProcess, args: &[Value]) -> BifResult {
+pub fn bif_erlang_process_flag_2(_vm: &vm::Machine, process: &RcProcess, args: &[Term]) -> BifResult {
     match &args[0] {
-        Value::Atom(atom::TRAP_EXIT) => {
+        Term::atom(atom::TRAP_EXIT) => {
             let context = process.context_mut();
             let old_value = context.flags.contains(process::Flag::TRAP_EXIT);
             match &args[1] { // TODO atom to_bool, then pass that in as 2 arg
-                Value::Atom(atom::TRUE) => context.flags.set(process::Flag::TRAP_EXIT, true),
-                Value::Atom(atom::FALSE) => context.flags.set(process::Flag::TRAP_EXIT, false),
+                Term::atom(atom::TRUE) => context.flags.set(process::Flag::TRAP_EXIT, true),
+                Term::atom(atom::FALSE) => context.flags.set(process::Flag::TRAP_EXIT, false),
                 _ => return Err(Exception::new(Reason::EXC_BADARG))
             }
             if old_value { // todo helper func From<>
-                return Ok(Value::Atom(atom::TRUE));
+                return Ok(Term::atom(atom::TRUE));
             } else {
-                return Ok(Value::Atom(atom::FALSE));
+                return Ok(Term::atom(atom::FALSE));
             }
         },
-        Value::Atom(i) => unimplemented!("erlang:process_flag/2 not implemented for {:?}", atom::from_index(*i)),
+        Term::atom(i) => unimplemented!("erlang:process_flag/2 not implemented for {:?}", atom::from_index(*i)),
         _ => unreachable!()
     }
 }
 
 
 /// register(atom, Process|Port) registers a global process or port (for this node)
-fn bif_erlang_register_2(vm: &vm::Machine, process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_erlang_register_2(vm: &vm::Machine, process: &RcProcess, args: &[Term]) -> BifResult {
     /* (Atom, Pid|Port)   */
     if let Value::Atom(name) = args[0] {
         vm.state.process_registry.lock().register(name, process.clone());
-        return Ok(Value::Atom(atom::TRUE))
+        return Ok(atom!(TRUE))
     }
     Err(Exception::new(Reason::EXC_BADARG))
 }
 
-fn bif_erlang_function_exported_3(vm: &vm::Machine, process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_erlang_function_exported_3(vm: &vm::Machine, process: &RcProcess, args: &[Term]) -> BifResult {
     if !args[0].is_atom() || !args[1].is_atom() || !args[2].is_smallint() {
         return Err(Exception::new(Reason::EXC_BADARG))
     }
@@ -481,19 +481,19 @@ fn bif_erlang_function_exported_3(vm: &vm::Machine, process: &RcProcess, args: &
     let mfa = (args[0].to_u32(), args[1].to_u32(), arity);
 
     if vm.exports.read().lookup(&mfa).is_some() || bif::is_bif(&mfa) {
-        return Ok(Value::Atom(atom::TRUE));
+        return Ok(atom!(TRUE));
     }
-    Ok(Value::Atom(atom::FALSE))
+    Ok(atom!(FALSE))
 }
 
 // Process dictionary
 
 /// Get the whole pdict.
-fn bif_erlang_get_0(_vm: &vm::Machine, process: &RcProcess, _args: &[Value]) -> BifResult {
+fn bif_erlang_get_0(_vm: &vm::Machine, process: &RcProcess, _args: &[Term]) -> BifResult {
     let pdict = &process.local_data_mut().dictionary;
     let heap = &process.context_mut().heap;
 
-    let result: Value = pdict.iter().fold(Value::Nil, |res, (key, val)| {
+    let result: Term = pdict.iter().fold(Term::nil(), |res, (key, val)| {
         // make tuple
         let tuple = tup2!(heap, key.clone(), val.clone());
 
@@ -504,31 +504,31 @@ fn bif_erlang_get_0(_vm: &vm::Machine, process: &RcProcess, _args: &[Value]) -> 
 }
 
 /// Get the value for key in pdict.
-fn bif_erlang_get_1(_vm: &vm::Machine, process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_erlang_get_1(_vm: &vm::Machine, process: &RcProcess, args: &[Term]) -> BifResult {
     let pdict = &process.local_data_mut().dictionary;
     Ok(pdict
         .get(&(args[0]))
         .cloned() // TODO: try to avoid the clone if possible
-        .unwrap_or_else(|| Value::Atom(atom::UNDEFINED)))
+        .unwrap_or_else(|| atom!(UNDEFINED)))
 }
 
 /// Get all the keys in pdict.
-fn bif_erlang_get_keys_0(_vm: &vm::Machine, process: &RcProcess, _args: &[Value]) -> BifResult {
+fn bif_erlang_get_keys_0(_vm: &vm::Machine, process: &RcProcess, _args: &[Term]) -> BifResult {
     let pdict = &process.local_data_mut().dictionary;
     let heap = &process.context_mut().heap;
 
-    let result: Value = pdict
+    let result: Term = pdict
         .keys()
-        .fold(Value::Nil, |res, key| value::cons(heap, key.clone(), res));
+        .fold(Term::nil(), |res, key| value::cons(heap, key.clone(), res));
     Ok(result)
 }
 
 /// Return all the keys that have val
-fn bif_erlang_get_keys_1(_vm: &vm::Machine, process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_erlang_get_keys_1(_vm: &vm::Machine, process: &RcProcess, args: &[Term]) -> BifResult {
     let pdict = &process.local_data_mut().dictionary;
     let heap = &process.context_mut().heap;
 
-    let result: Value = pdict.iter().fold(Value::Nil, |res, (key, val)| {
+    let result: Term = pdict.iter().fold(Term::nil(), |res, (key, val)| {
         if args[1] == *val {
             value::cons(heap, key.clone(), res)
         } else {
@@ -539,21 +539,21 @@ fn bif_erlang_get_keys_1(_vm: &vm::Machine, process: &RcProcess, args: &[Value])
 }
 
 /// Set the key to val. Return undefined if a key was inserted, or old val if it was updated.
-fn bif_erlang_put_2(_vm: &vm::Machine, process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_erlang_put_2(_vm: &vm::Machine, process: &RcProcess, args: &[Term]) -> BifResult {
     let pdict = &mut process.local_data_mut().dictionary;
     Ok(pdict
         .insert(args[0].clone(), args[1].clone())
-        .unwrap_or_else(|| Value::Atom(atom::UNDEFINED)))
+        .unwrap_or_else(|| atom!(UNDEFINED)))
 }
 
 /// Remove all pdict entries, returning the pdict.
-fn bif_erlang_erase_0(_vm: &vm::Machine, process: &RcProcess, _args: &[Value]) -> BifResult {
+fn bif_erlang_erase_0(_vm: &vm::Machine, process: &RcProcess, _args: &[Term]) -> BifResult {
     // deletes all the entries, returning the whole dict tuple
     let pdict = &mut process.local_data_mut().dictionary;
     let heap = &process.context_mut().heap;
 
     // we use drain since it means we do a move instead of a copy
-    let result: Value = pdict.drain().fold(Value::Nil, |res, (key, val)| {
+    let result: Term = pdict.drain().fold(Term::nil(), |res, (key, val)| {
         // make tuple
         let tuple = tup2!(heap, key, val);
 
@@ -564,22 +564,22 @@ fn bif_erlang_erase_0(_vm: &vm::Machine, process: &RcProcess, _args: &[Value]) -
 }
 
 /// Remove a single entry from the pdict and return it.
-fn bif_erlang_erase_1(_vm: &vm::Machine, process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_erlang_erase_1(_vm: &vm::Machine, process: &RcProcess, args: &[Term]) -> BifResult {
     // deletes a single entry, returning the val
     let pdict = &mut process.local_data_mut().dictionary;
     Ok(pdict
         .remove(&(args[0]))
-        .unwrap_or_else(|| Value::Atom(atom::UNDEFINED)))
+        .unwrap_or_else(|| atom!(UNDEFINED)))
 }
 
-fn bif_lists_member_2(_vm: &vm::Machine, process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_lists_member_2(_vm: &vm::Machine, process: &RcProcess, args: &[Term]) -> BifResult {
     // need to bump reductions as we go
     let reds_left = 1; // read from process
     let mut max_iter = 16 * reds_left;
     // bool non_immed_key;
 
     if args[1].is_nil() {
-        return Ok(Value::Atom(atom::FALSE));
+        return Ok(atom!(FALSE));
     } else if !args[1].is_list() {
         return Err(Exception::new(Reason::EXC_BADARG));
     }
@@ -602,7 +602,7 @@ fn bif_lists_member_2(_vm: &vm::Machine, process: &RcProcess, args: &[Value]) ->
             if *item == *term {
                 // || (non_immed_key && deep_equals) {
                 // BIF_RET2(am_true, reds_left - max_iter/16);
-                return Ok(Value::Atom(atom::TRUE));
+                return Ok(atom!(TRUE));
             }
             list = &(*l).tail;
         }
@@ -612,7 +612,7 @@ fn bif_lists_member_2(_vm: &vm::Machine, process: &RcProcess, args: &[Value]) ->
         // BUMP_REDS(BIF_P, reds_left - max_iter/16);
         return Err(Exception::new(Reason::EXC_BADARG));
     }
-    Ok(Value::Atom(atom::FALSE)) // , reds_left - max_iter/16
+    Ok(atom!(FALSE)) // , reds_left - max_iter/16
 }
 
 // static BIF_RETTYPE lists_reverse_alloc(Process *c_p,
@@ -717,7 +717,7 @@ fn bif_lists_member_2(_vm: &vm::Machine, process: &RcProcess, args: &[Value]) ->
 //     BIF_ERROR(c_p, BADARG);
 // }
 
-fn bif_lists_reverse_2(_vm: &vm::Machine, process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_lists_reverse_2(_vm: &vm::Machine, process: &RcProcess, args: &[Term]) -> BifResult {
     // Handle legal and illegal non-lists quickly.
     if args[0].is_nil() {
         return Ok(args[1].clone());
@@ -737,34 +737,34 @@ fn bif_lists_reverse_2(_vm: &vm::Machine, process: &RcProcess, args: &[Value]) -
     unimplemented!()
 }
 
-fn bif_lists_keymember_3(_vm: &vm::Machine, process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_lists_keymember_3(_vm: &vm::Machine, process: &RcProcess, args: &[Term]) -> BifResult {
     let res = keyfind(bif_lists_keyfind_3, process, args);
 
     if let Ok(Value::Tuple(..)) = res {
-        return Ok(Value::Atom(atom::TRUE));
+        return Ok(atom!(TRUE));
     }
     res
 }
 
-fn bif_lists_keysearch_3(_vm: &vm::Machine, process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_lists_keysearch_3(_vm: &vm::Machine, process: &RcProcess, args: &[Term]) -> BifResult {
     let res = keyfind(bif_lists_keyfind_3, process, args);
 
     if let Ok(Value::Tuple(t)) = res {
         let heap = &process.context_mut().heap;
-        let tuple = tup2!(heap, Value::Atom(atom::VALUE), Value::Tuple(t));
+        let tuple = tup2!(heap, atom!(VALUE), Value::Tuple(t));
         return Ok(tuple);
     }
     res
 }
 
-fn bif_lists_keyfind_3(_vm: &vm::Machine, process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_lists_keyfind_3(_vm: &vm::Machine, process: &RcProcess, args: &[Term]) -> BifResult {
     keyfind(bif_lists_keyfind_3, process, args)
 }
 
 // kept the original OTP comment
 /* returns the head of a list - this function is unecessary
 and is only here to keep Robert happy (Even more, since it's OP as well) */
-fn bif_erlang_hd_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_erlang_hd_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     if let Value::List(cons) = args[0] {
         unsafe { return Ok((*cons).head.clone()) }
     }
@@ -772,16 +772,16 @@ fn bif_erlang_hd_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> B
 }
 
 /* returns the tails of a list - same comment as above */
-fn bif_erlang_tl_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_erlang_tl_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     if let Value::List(cons) = args[0] {
         unsafe { return Ok((*cons).tail.clone()) }
     }
     Err(Exception::new(Reason::EXC_BADARG))
 }
 
-fn bif_erlang_trunc_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+fn bif_erlang_trunc_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     match &args[0] {
-        Value::Integer(i) => Ok(Value::Integer(*i)),
+        Value::Integer(i) => Ok(Term::int(*i)),
         Value::Float(value::Float(f)) => Ok(Value::Float(value::Float(f.trunc()))),
         Value::BigInt(v) => Ok(Value::BigInt(v.clone())),
         _ => Err(Exception::new(Reason::EXC_BADARG)),
@@ -791,7 +791,7 @@ fn bif_erlang_trunc_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -
 /// Swap process out after this number
 const CONTEXT_REDS: usize = 4000;
 
-fn keyfind(_func: BifFn, _process: &RcProcess, args: &[Value]) -> BifResult {
+fn keyfind(_func: BifFn, _process: &RcProcess, args: &[Term]) -> BifResult {
     let mut max_iter: isize = 10 * CONTEXT_REDS as isize;
 
     let key = &args[0];
@@ -823,7 +823,7 @@ fn keyfind(_func: BifFn, _process: &RcProcess, args: &[Value]) -> BifResult {
     if !list.is_nil() {
         // BIF_ERROR(p, BADARG);
     }
-    Ok(Value::Atom(atom::FALSE))
+    Ok(atom!(FALSE))
 }
 
 #[cfg(test)]
@@ -832,7 +832,7 @@ mod tests {
     use crate::immix::Heap;
 
     /// Converts an erlang list to a value vector.
-    fn to_vec(value: Value) -> Vec<Value> {
+    fn to_vec(value: Term) -> Vec<Term> {
         let mut vec = Vec::new();
         unsafe {
             let mut cons = &value;
@@ -847,10 +847,10 @@ mod tests {
     }
 
     /// Converts a value vector to an erlang list.
-    fn from_vec(heap: &Heap, vec: Vec<Value>) -> Value {
+    fn from_vec(heap: &Heap, vec: Vec<Term>) -> Term {
         vec.into_iter()
             .rev()
-            .fold(Value::Nil, |res, val| value::cons(heap, val, res))
+            .fold(Term::nil(), |res, val| value::cons(heap, val, res))
     }
 
     #[test]
@@ -858,9 +858,9 @@ mod tests {
         let vm = vm::Machine::new();
         let module: *const module::Module = std::ptr::null();
         let process = process::allocate(&vm.state, module).unwrap();
-        let args = vec![Value::Integer(-1)];
+        let args = vec![Term::int(-1)];
         let res = bif_erlang_abs_1(&vm, &process, &args);
-        assert_eq!(res, Ok(Value::Integer(1)));
+        assert_eq!(res, Ok(Term::int(1)));
     }
 
     #[test]
@@ -868,9 +868,9 @@ mod tests {
         let vm = vm::Machine::new();
         let module: *const module::Module = std::ptr::null();
         let process = process::allocate(&vm.state, module).unwrap();
-        let args = vec![Value::Integer(1), Value::Integer(2)];
+        let args = vec![Term::int(1), Term::int(2)];
         let res = bif_erlang_add_2(&vm, &process, &args);
-        assert_eq!(res, Ok(Value::Integer(3)));
+        assert_eq!(res, Ok(Term::int(3)));
     }
 
     #[test]
@@ -878,9 +878,9 @@ mod tests {
         let vm = vm::Machine::new();
         let module: *const module::Module = std::ptr::null();
         let process = process::allocate(&vm.state, module).unwrap();
-        let args = vec![Value::Integer(2), Value::Integer(1)];
+        let args = vec![Term::int(2), Term::int(1)];
         let res = bif_erlang_sub_2(&vm, &process, &args);
-        assert_eq!(res, Ok(Value::Integer(1)));
+        assert_eq!(res, Ok(Term::int(1)));
     }
 
     #[test]
@@ -888,9 +888,9 @@ mod tests {
         let vm = vm::Machine::new();
         let module: *const module::Module = std::ptr::null();
         let process = process::allocate(&vm.state, module).unwrap();
-        let args = vec![Value::Integer(2), Value::Integer(4)];
+        let args = vec![Term::int(2), Term::int(4)];
         let res = bif_erlang_mult_2(&vm, &process, &args);
-        assert_eq!(res, Ok(Value::Integer(8)));
+        assert_eq!(res, Ok(Term::int(8)));
     }
 
     #[test]
@@ -898,9 +898,9 @@ mod tests {
         let vm = vm::Machine::new();
         let module: *const module::Module = std::ptr::null();
         let process = process::allocate(&vm.state, module).unwrap();
-        let args = vec![Value::Integer(8), Value::Integer(4)];
+        let args = vec![Term::int(8), Term::int(4)];
         let res = bif_erlang_intdiv_2(&vm, &process, &args);
-        assert_eq!(res, Ok(Value::Integer(2)));
+        assert_eq!(res, Ok(Term::int(2)));
     }
 
     #[test]
@@ -908,9 +908,9 @@ mod tests {
         let vm = vm::Machine::new();
         let module: *const module::Module = std::ptr::null();
         let process = process::allocate(&vm.state, module).unwrap();
-        let args = vec![Value::Integer(4), Value::Integer(3)];
+        let args = vec![Term::int(4), Term::int(3)];
         let res = bif_erlang_mod_2(&vm, &process, &args);
-        assert_eq!(res, Ok(Value::Integer(1)));
+        assert_eq!(res, Ok(Term::int(1)));
     }
 
     #[test]
@@ -931,11 +931,11 @@ mod tests {
         let module: *const module::Module = std::ptr::null();
         let process = process::allocate(&vm.state, module).unwrap();
 
-        let args = vec![Value::Atom(3)];
+        let args = vec![Term::atom(3)];
         let res = bif_erlang_is_atom_1(&vm, &process, &args);
         assert_eq!(res, Ok(atom!(TRUE)));
 
-        let args = vec![Value::Integer(3)];
+        let args = vec![Term::int(3)];
         let res = bif_erlang_is_atom_1(&vm, &process, &args);
         assert_eq!(res, Ok(atom!(FALSE)));
     }
@@ -947,11 +947,11 @@ mod tests {
         let process = process::allocate(&vm.state, module).unwrap();
 
         let heap = &Heap::new();
-        let args = vec![tup2!(heap, Value::Integer(1), Value::Integer(2))];
+        let args = vec![tup2!(heap, Term::int(1), Term::int(2))];
         let res = bif_erlang_is_tuple_1(&vm, &process, &args);
         assert_eq!(res, Ok(atom!(TRUE)));
 
-        let args = vec![Value::Integer(3)];
+        let args = vec![Term::int(3)];
         let res = bif_erlang_is_tuple_1(&vm, &process, &args);
         assert_eq!(res, Ok(atom!(FALSE)));
     }
@@ -963,11 +963,11 @@ mod tests {
         let process = process::allocate(&vm.state, module).unwrap();
 
         let heap = &Heap::new();
-        let args = vec![value::cons(heap, Value::Integer(1), Value::Integer(2))];
+        let args = vec![value::cons(heap, Term::int(1), Term::int(2))];
         let res = bif_erlang_is_list_1(&vm, &process, &args);
         assert_eq!(res, Ok(atom!(TRUE)));
 
-        let args = vec![Value::Integer(3)];
+        let args = vec![Term::int(3)];
         let res = bif_erlang_is_list_1(&vm, &process, &args);
         assert_eq!(res, Ok(atom!(FALSE)));
     }
@@ -981,7 +981,7 @@ mod tests {
         let res = bif_erlang_is_float_1(&vm, &process, &args);
         assert_eq!(res, Ok(atom!(TRUE)));
 
-        let args = vec![Value::Integer(3)];
+        let args = vec![Term::int(3)];
         let res = bif_erlang_is_float_1(&vm, &process, &args);
         assert_eq!(res, Ok(atom!(FALSE)));
     }
@@ -992,11 +992,11 @@ mod tests {
         let module: *const module::Module = std::ptr::null();
         let process = process::allocate(&vm.state, module).unwrap();
 
-        let args = vec![Value::Integer(3)];
+        let args = vec![Term::int(3)];
         let res = bif_erlang_is_integer_1(&vm, &process, &args);
         assert_eq!(res, Ok(atom!(TRUE)));
 
-        let args = vec![Value::Atom(3)];
+        let args = vec![Term::atom(3)];
         let res = bif_erlang_is_integer_1(&vm, &process, &args);
         assert_eq!(res, Ok(atom!(FALSE)));
     }
@@ -1007,7 +1007,7 @@ mod tests {
         let module: *const module::Module = std::ptr::null();
         let process = process::allocate(&vm.state, module).unwrap();
 
-        let args = vec![Value::Integer(3)];
+        let args = vec![Term::int(3)];
         let res = bif_erlang_is_number_1(&vm, &process, &args);
         assert_eq!(res, Ok(atom!(TRUE)));
 
@@ -1019,7 +1019,7 @@ mod tests {
         let res = bif_erlang_is_number_1(&vm, &process, &args);
         assert_eq!(res, Ok(atom!(TRUE)));
 
-        let args = vec![Value::Atom(3)];
+        let args = vec![Term::atom(3)];
         let res = bif_erlang_is_number_1(&vm, &process, &args);
         assert_eq!(res, Ok(atom!(FALSE)));
     }
@@ -1034,7 +1034,7 @@ mod tests {
         let res = bif_erlang_is_port_1(&vm, &process, &args);
         assert_eq!(res, Ok(atom!(TRUE)));
 
-        let args = vec![Value::Atom(3)];
+        let args = vec![Term::atom(3)];
         let res = bif_erlang_is_port_1(&vm, &process, &args);
         assert_eq!(res, Ok(atom!(FALSE)));
     }
@@ -1049,7 +1049,7 @@ mod tests {
         let res = bif_erlang_is_reference_1(&vm, &process, &args);
         assert_eq!(res, Ok(atom!(TRUE)));
 
-        let args = vec![Value::Atom(3)];
+        let args = vec![Term::atom(3)];
         let res = bif_erlang_is_reference_1(&vm, &process, &args);
         assert_eq!(res, Ok(atom!(FALSE)));
     }
@@ -1065,7 +1065,7 @@ mod tests {
         let res = bif_erlang_is_binary_1(&vm, &process, &args);
         assert_eq!(res, Ok(atom!(TRUE)));
 
-        let args = vec![Value::Atom(3)];
+        let args = vec![Term::atom(3)];
         let res = bif_erlang_is_binary_1(&vm, &process, &args);
         assert_eq!(res, Ok(atom!(FALSE)));
     }
@@ -1080,7 +1080,7 @@ mod tests {
         let res = bif_erlang_is_function_1(&vm, &process, &args);
         assert_eq!(res, Ok(atom!(TRUE)));
 
-        let args = vec![Value::Atom(3)];
+        let args = vec![Term::atom(3)];
         let res = bif_erlang_is_function_1(&vm, &process, &args);
         assert_eq!(res, Ok(atom!(FALSE)));
     }
@@ -1090,11 +1090,11 @@ mod tests {
         let module: *const module::Module = std::ptr::null();
         let process = process::allocate(&vm.state, module).unwrap();
 
-        let args = vec![Value::Atom(atom::TRUE)];
+        let args = vec![Term::atom(atom::TRUE)];
         let res = bif_erlang_is_boolean_1(&vm, &process, &args);
         assert_eq!(res, Ok(atom!(TRUE)));
 
-        let args = vec![Value::Atom(3)];
+        let args = vec![Term::atom(3)];
         let res = bif_erlang_is_boolean_1(&vm, &process, &args);
         assert_eq!(res, Ok(atom!(FALSE)));
     }
@@ -1105,12 +1105,12 @@ mod tests {
         let module: *const module::Module = std::ptr::null();
         let process = process::allocate(&vm.state, module).unwrap();
 
-        let map = map!(Value::Atom(1) => Value::Integer(1));
+        let map = map!(Term::atom(1) => Term::int(1));
         let args = vec![map];
         let res = bif_erlang_is_map_1(&vm, &process, &args);
         assert_eq!(res, Ok(atom!(TRUE)));
 
-        let args = vec![Value::Atom(3)];
+        let args = vec![Term::atom(3)];
         let res = bif_erlang_is_map_1(&vm, &process, &args);
         assert_eq!(res, Ok(atom!(FALSE)));
     }
@@ -1120,7 +1120,7 @@ mod tests {
         let vm = vm::Machine::new();
         let module: *const module::Module = std::ptr::null();
         let process = process::allocate(&vm.state, module).unwrap();
-        let args = vec![Value::Integer(1)];
+        let args = vec![Term::int(1)];
         let res = bif_math_cos_1(&vm, &process, &args);
         assert_eq!(res, Ok(Value::Float(value::Float(1.0_f64.cos()))));
 
@@ -1138,10 +1138,10 @@ mod tests {
         let process = process::allocate(&vm.state, module).unwrap();
 
         let heap = &Heap::new();
-        let args = vec![tup3!(heap, Value::Integer(1), Value::Integer(2), Value::Integer(1))];
+        let args = vec![tup3!(heap, Term::int(1), Term::int(2), Term::int(1))];
         let res = bif_erlang_tuple_size_1(&vm, &process, &args);
 
-        assert_eq!(res, Ok(Value::Integer(3)));
+        assert_eq!(res, Ok(Term::int(3)));
     }
 
     #[test]
@@ -1150,26 +1150,26 @@ mod tests {
         let module: *const module::Module = std::ptr::null();
         let process = process::allocate(&vm.state, module).unwrap();
 
-        let args = vec![Value::Atom(1), Value::Integer(2)];
+        let args = vec![Term::atom(1), Term::int(2)];
         let res = bif_erlang_put_2(&vm, &process, &args);
         assert_eq!(res, Ok(atom!(UNDEFINED)));
 
-        let args = vec![Value::Atom(1), Value::Integer(3)];
+        let args = vec![Term::atom(1), Term::int(3)];
         let res = bif_erlang_put_2(&vm, &process, &args);
-        assert_eq!(res, Ok(Value::Integer(2)));
+        assert_eq!(res, Ok(Term::int(2)));
 
-        let args = vec![Value::Atom(2), Value::Integer(1)];
+        let args = vec![Term::atom(2), Term::int(1)];
         let res = bif_erlang_put_2(&vm, &process, &args);
         assert_eq!(res, Ok(atom!(UNDEFINED)));
 
-        let args = vec![Value::Atom(2)];
+        let args = vec![Term::atom(2)];
         let res = bif_erlang_get_1(&vm, &process, &args);
-        assert_eq!(res, Ok(Value::Integer(1)));
+        assert_eq!(res, Ok(Term::int(1)));
 
         // TODO: add a assert helper for lists
         let args = vec![];
         let res = bif_erlang_get_0(&vm, &process, &args);
-        // assert_eq!(res, Ok(Value::Integer(1)));
+        // assert_eq!(res, Ok(Term::int(1)));
     }
 
     #[test]
@@ -1179,13 +1179,13 @@ mod tests {
         let process = process::allocate(&vm.state, module).unwrap();
         let heap = &process.context_mut().heap;
 
-        let elem = Value::Atom(1);
-        let list = from_vec(heap, vec![Value::Atom(3), Value::Atom(2)]);
+        let elem = Term::atom(1);
+        let list = from_vec(heap, vec![Term::atom(3), Term::atom(2)]);
         let res = bif_lists_member_2(&vm, &process, &[elem, list]);
         assert_eq!(res, Ok(atom!(FALSE)));
 
-        let elem = Value::Atom(1);
-        let list = from_vec(heap, vec![Value::Atom(3), Value::Atom(2), Value::Atom(1)]);
+        let elem = Term::atom(1);
+        let list = from_vec(heap, vec![Term::atom(3), Term::atom(2), Term::atom(1)]);
         let res = bif_lists_member_2(&vm, &process, &[elem, list]);
         assert_eq!(res, Ok(atom!(TRUE)));
     }
@@ -1197,22 +1197,22 @@ mod tests {
         let process = process::allocate(&vm.state, module).unwrap();
         let heap = &process.context_mut().heap;
 
-        let elem = Value::Atom(1);
-        let pos = Value::Integer(5);
+        let elem = Term::atom(1);
+        let pos = Term::int(5);
         let list = from_vec(heap, vec![]);
         let res = bif_lists_keyfind_3(&vm, &process, &[elem, pos, list]);
         assert_eq!(res, Ok(atom!(FALSE)));
 
-        let elem = Value::Atom(3);
-        let pos = Value::Integer(0);
-        let target = tup2!(heap, Value::Atom(3), Value::Integer(2));
+        let elem = Term::atom(3);
+        let pos = Term::int(0);
+        let target = tup2!(heap, Term::atom(3), Term::int(2));
         let list = from_vec(
             heap,
             vec![
-                tup2!(heap, Value::Atom(1), Value::Integer(4)),
-                tup2!(heap, Value::Atom(2), Value::Integer(3)),
+                tup2!(heap, Term::atom(1), Term::int(4)),
+                tup2!(heap, Term::atom(2), Term::int(3)),
                 target.clone(),
-                tup2!(heap, Value::Atom(4), Value::Integer(1)),
+                tup2!(heap, Term::atom(4), Term::int(1)),
             ],
         );
         let res = bif_lists_keyfind_3(&vm, &process, &[elem, pos, list]);

--- a/src/bif.rs
+++ b/src/bif.rs
@@ -145,8 +145,8 @@ pub fn apply(
 //     .iter()
 //     .map(|mfa| {
 //         (
-//             atom::from_index(&mfa.0).unwrap(),
-//             atom::from_index(&mfa.1).unwrap(),
+//             atom::to_str(&mfa.0).unwrap(),
+//             atom::to_str(&mfa.1).unwrap(),
 //             mfa.2,
 //         )
 //     })
@@ -456,7 +456,7 @@ pub fn bif_erlang_process_flag_2(_vm: &vm::Machine, process: &RcProcess, args: &
                 return Ok(Term::atom(atom::FALSE));
             }
         },
-        Term::atom(i) => unimplemented!("erlang:process_flag/2 not implemented for {:?}", atom::from_index(*i)),
+        Term::atom(i) => unimplemented!("erlang:process_flag/2 not implemented for {:?}", atom::to_str(*i)),
         _ => unreachable!()
     }
 }

--- a/src/bif.rs
+++ b/src/bif.rs
@@ -176,30 +176,35 @@ fn bif_erlang_abs_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> B
     }
 }
 
-fn bif_erlang_add_2(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
-    Ok(integer_overflow_op!(None, args, add, overflowing_add))
+fn bif_erlang_add_2(_vm: &vm::Machine, process: &RcProcess, args: &[Term]) -> BifResult {
+    let heap = &process.context_mut().heap;
+    Ok(integer_overflow_op!(heap, args, add, overflowing_add))
 }
 
-fn bif_erlang_sub_2(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
-    Ok(integer_overflow_op!(None, args, sub, overflowing_sub))
+fn bif_erlang_sub_2(_vm: &vm::Machine, process: &RcProcess, args: &[Term]) -> BifResult {
+    let heap = &process.context_mut().heap;
+    Ok(integer_overflow_op!(heap, args, sub, overflowing_sub))
 }
 
-fn bif_erlang_mult_2(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
-    Ok(integer_overflow_op!(None, args, mul, overflowing_mul))
+fn bif_erlang_mult_2(_vm: &vm::Machine, process: &RcProcess, args: &[Term]) -> BifResult {
+    let heap = &process.context_mut().heap;
+    Ok(integer_overflow_op!(heap, args, mul, overflowing_mul))
 }
 
-fn bif_erlang_intdiv_2(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
+fn bif_erlang_intdiv_2(_vm: &vm::Machine, process: &RcProcess, args: &[Term]) -> BifResult {
+    let heap = &process.context_mut().heap;
     Ok(integer_overflow_op!(
-        None,
+        heap,
         args,
         floored_division,
         overflowing_floored_division
     ))
 }
 
-fn bif_erlang_mod_2(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
+fn bif_erlang_mod_2(_vm: &vm::Machine, process: &RcProcess, args: &[Term]) -> BifResult {
     // TODO: should be rem but it's mod
-    Ok(integer_overflow_op!(None, args, modulo, overflowing_modulo))
+    let heap = &process.context_mut().heap;
+    Ok(integer_overflow_op!(heap, args, modulo, overflowing_modulo))
 }
 
 fn bif_erlang_self_0(_vm: &vm::Machine, process: &RcProcess, _args: &[Term]) -> BifResult {

--- a/src/bif.rs
+++ b/src/bif.rs
@@ -805,8 +805,8 @@ fn keyfind(_func: BifFn, _process: &RcProcess, args: &[Term]) -> BifResult {
 
         let term = head;
         list = tail;
-        if let Ok(ptr) = term.try_into() {
-            let tuple: &Tuple = ptr; // annoying, need type annotation
+        if let Ok(tuple) = term.try_into() {
+            let tuple: &Tuple = tuple; // annoying, need type annotation
             if pos <= (tuple.len as usize) && *key == tuple[pos] {
                 return Ok(term.clone());
             }

--- a/src/bif/chrono.rs
+++ b/src/bif/chrono.rs
@@ -1,6 +1,6 @@
 use crate::bif::BifResult;
 use crate::process::RcProcess;
-use crate::value::{self, Value};
+use crate::value::{self, Term};
 use crate::vm;
 use chrono::{Datelike, Local, Timelike, Utc};
 use num::bigint::ToBigInt;
@@ -10,38 +10,34 @@ use std::time::SystemTime;
 /// http://erlang.org/doc/apps/erts/time_correction.html#Erlang_System_Time
 
 #[inline]
-pub fn bif_erlang_date_0(_vm: &vm::Machine, process: &RcProcess, _args: &[Value]) -> BifResult {
+pub fn bif_erlang_date_0(_vm: &vm::Machine, process: &RcProcess, _args: &[Term]) -> BifResult {
     let heap = &process.context_mut().heap;
     let date = Local::today();
 
     Ok(tup3!(
         heap,
-        Value::Integer(i64::from(date.year())),
-        Value::Integer(i64::from(date.month())),
-        Value::Integer(i64::from(date.day()))
+        Term::int(i32::from(date.year())),
+        Term::int(i32::from(date.month())),
+        Term::int(i32::from(date.day()))
     ))
 }
 
 #[inline]
-pub fn bif_erlang_localtime_0(
-    _vm: &vm::Machine,
-    process: &RcProcess,
-    _args: &[Value],
-) -> BifResult {
+pub fn bif_erlang_localtime_0(_vm: &vm::Machine, process: &RcProcess, _args: &[Term]) -> BifResult {
     let heap = &process.context_mut().heap;
     let datetime = Local::now();
 
     let date = tup3!(
         heap,
-        Value::Integer(i64::from(datetime.year())),
-        Value::Integer(i64::from(datetime.month())),
-        Value::Integer(i64::from(datetime.day()))
+        Term::int(i32::from(datetime.year())),
+        Term::int(i32::from(datetime.month())),
+        Term::int(i32::from(datetime.day()))
     );
     let time = tup3!(
         heap,
-        Value::Integer(i64::from(datetime.hour())),
-        Value::Integer(i64::from(datetime.minute())),
-        Value::Integer(i64::from(datetime.second()))
+        Term::int(i32::from(datetime.hour())),
+        Term::int(i32::from(datetime.minute())),
+        Term::int(i32::from(datetime.second()))
     );
     Ok(tup2!(heap, date, time))
 }
@@ -51,7 +47,7 @@ pub fn bif_erlang_localtime_0(
 pub fn bif_erlang_monotonic_time_0(
     vm: &vm::Machine,
     _process: &RcProcess,
-    _args: &[Value],
+    _args: &[Term],
 ) -> BifResult {
     // TODO: needs https://github.com/rust-lang/rust/issues/50202
     // .as_nanos()
@@ -66,7 +62,7 @@ pub fn bif_erlang_monotonic_time_0(
 pub fn bif_erlang_system_time_0(
     _vm: &vm::Machine,
     _process: &RcProcess,
-    _args: &[Value],
+    _args: &[Term],
 ) -> BifResult {
     Ok(Value::BigInt(Box::new(
         SystemTime::now()
@@ -94,22 +90,22 @@ pub fn bif_erlang_system_time_0(
 pub fn bif_erlang_universaltime_0(
     _vm: &vm::Machine,
     process: &RcProcess,
-    _args: &[Value],
+    _args: &[Term],
 ) -> BifResult {
     let heap = &process.context_mut().heap;
     let datetime = Utc::now();
 
     let date = tup3!(
         heap,
-        Value::Integer(i64::from(datetime.year())),
-        Value::Integer(i64::from(datetime.month())),
-        Value::Integer(i64::from(datetime.day()))
+        Term::int(i32::from(datetime.year())),
+        Term::int(i32::from(datetime.month())),
+        Term::int(i32::from(datetime.day()))
     );
     let time = tup3!(
         heap,
-        Value::Integer(i64::from(datetime.hour())),
-        Value::Integer(i64::from(datetime.minute())),
-        Value::Integer(i64::from(datetime.second()))
+        Term::int(i32::from(datetime.hour())),
+        Term::int(i32::from(datetime.minute())),
+        Term::int(i32::from(datetime.second()))
     );
     Ok(tup2!(heap, date, time))
 }

--- a/src/bif/chrono.rs
+++ b/src/bif/chrono.rs
@@ -16,9 +16,9 @@ pub fn bif_erlang_date_0(_vm: &vm::Machine, process: &RcProcess, _args: &[Term])
 
     Ok(tup3!(
         heap,
-        Term::int(i32::from(date.year())),
-        Term::int(i32::from(date.month())),
-        Term::int(i32::from(date.day()))
+        Term::int(date.year() as i32),
+        Term::int(date.month() as i32),
+        Term::int(date.day() as i32)
     ))
 }
 
@@ -29,15 +29,15 @@ pub fn bif_erlang_localtime_0(_vm: &vm::Machine, process: &RcProcess, _args: &[T
 
     let date = tup3!(
         heap,
-        Term::int(i32::from(datetime.year())),
-        Term::int(i32::from(datetime.month())),
-        Term::int(i32::from(datetime.day()))
+        Term::int(datetime.year() as i32),
+        Term::int(datetime.month() as i32),
+        Term::int(datetime.day() as i32)
     );
     let time = tup3!(
         heap,
-        Term::int(i32::from(datetime.hour())),
-        Term::int(i32::from(datetime.minute())),
-        Term::int(i32::from(datetime.second()))
+        Term::int(datetime.hour() as i32),
+        Term::int(datetime.minute() as i32),
+        Term::int(datetime.second() as i32)
     );
     Ok(tup2!(heap, date, time))
 }
@@ -97,15 +97,15 @@ pub fn bif_erlang_universaltime_0(
 
     let date = tup3!(
         heap,
-        Term::int(i32::from(datetime.year())),
-        Term::int(i32::from(datetime.month())),
-        Term::int(i32::from(datetime.day()))
+        Term::int(datetime.year() as i32),
+        Term::int(datetime.month() as i32),
+        Term::int(datetime.day() as i32)
     );
     let time = tup3!(
         heap,
-        Term::int(i32::from(datetime.hour())),
-        Term::int(i32::from(datetime.minute())),
-        Term::int(i32::from(datetime.second()))
+        Term::int(datetime.hour() as i32),
+        Term::int(datetime.minute() as i32),
+        Term::int(datetime.second() as i32)
     );
     Ok(tup2!(heap, date, time))
 }

--- a/src/bif/chrono.rs
+++ b/src/bif/chrono.rs
@@ -52,7 +52,7 @@ pub fn bif_erlang_monotonic_time_0(
     // TODO: needs https://github.com/rust-lang/rust/issues/50202
     // .as_nanos()
 
-    Ok(Value::BigInt(Box::new(
+    Ok(Term::BigInt(Box::new(
         vm.elapsed_time().as_secs().to_bigint().unwrap(),
     )))
 }
@@ -64,7 +64,7 @@ pub fn bif_erlang_system_time_0(
     _process: &RcProcess,
     _args: &[Term],
 ) -> BifResult {
-    Ok(Value::BigInt(Box::new(
+    Ok(Term::BigInt(Box::new(
         SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap()

--- a/src/bif/chrono.rs
+++ b/src/bif/chrono.rs
@@ -46,32 +46,38 @@ pub fn bif_erlang_localtime_0(_vm: &vm::Machine, process: &RcProcess, _args: &[T
 
 pub fn bif_erlang_monotonic_time_0(
     vm: &vm::Machine,
-    _process: &RcProcess,
+    process: &RcProcess,
     _args: &[Term],
 ) -> BifResult {
     // TODO: needs https://github.com/rust-lang/rust/issues/50202
     // .as_nanos()
 
-    Ok(Term::BigInt(Box::new(
+    let heap = &process.context_mut().heap;
+
+    Ok(Term::bigint(
+        heap,
         vm.elapsed_time().as_secs().to_bigint().unwrap(),
-    )))
+    ))
 }
 
 // TODO monotonic_time_1
 
 pub fn bif_erlang_system_time_0(
     _vm: &vm::Machine,
-    _process: &RcProcess,
+    process: &RcProcess,
     _args: &[Term],
 ) -> BifResult {
-    Ok(Term::BigInt(Box::new(
+    let heap = &process.context_mut().heap;
+
+    Ok(Term::bigint(
+        heap,
         SystemTime::now()
             .duration_since(SystemTime::UNIX_EPOCH)
             .unwrap()
             .as_secs()
             .to_bigint()
             .unwrap(),
-    )))
+    ))
 }
 
 // TODO system_time_1

--- a/src/bif/map.rs
+++ b/src/bif/map.rs
@@ -42,18 +42,18 @@ pub fn bif_maps_get_2(_vm: &vm::Machine, process: &RcProcess, args: &[Term]) -> 
 pub fn bif_maps_from_list_1(_vm: &vm::Machine, process: &RcProcess, args: &[Term]) -> BifResult {
     let mut list = &args[0];
     if !list.is_list() {
-        return Err(Exception::with_value(Reason::EXC_BADARG, *list));
+        return Err(Exception::new(Reason::EXC_BADARG));
     }
     let mut map = HamtMap::new();
     while let Ok(value::Cons { head, tail }) = list.try_into() {
         if let Ok(tuple) = head.try_into() {
             let tuple: &value::Tuple = tuple; // annoying, need type annotation
             if tuple.len != 2 {
-                return Err(Exception::with_value(Reason::EXC_BADARG, *list));
+                return Err(Exception::new(Reason::EXC_BADARG));
             }
             map = map.plus(tuple[0], tuple[1]);
         } else {
-            return Err(Exception::with_value(Reason::EXC_BADARG, *list));
+            return Err(Exception::new(Reason::EXC_BADARG));
         }
         list = tail;
     }
@@ -314,7 +314,6 @@ mod tests {
 
         if let Err(exception) = res {
             assert_eq!(exception.reason, Reason::EXC_BADARG);
-            assert_eq!(exception.value, bad_list.clone());
         } else {
             panic!();
         }
@@ -342,7 +341,6 @@ mod tests {
 
         if let Err(exception) = res {
             assert_eq!(exception.reason, Reason::EXC_BADARG);
-            assert_eq!(exception.value, bad_tuple.clone());
         } else {
             panic!();
         }

--- a/src/bif/map.rs
+++ b/src/bif/map.rs
@@ -1,14 +1,12 @@
 use crate::atom;
-use crate::immix::Heap;
 use crate::bif::BifResult;
 use crate::exception::{Exception, Reason};
 use crate::process::RcProcess;
-use crate::value::{self, Value};
 use crate::servo_arc::Arc;
+use crate::value::{self, Term};
 use crate::vm;
-use hamt_rs::HamtMap;
 
-pub fn bif_maps_find_2(_vm: &vm::Machine, process: &RcProcess, args: &[Value]) -> BifResult {
+pub fn bif_maps_find_2(_vm: &vm::Machine, process: &RcProcess, args: &[Term]) -> BifResult {
     let key = &args[0];
     let map = &args[1];
     if let Value::Map(m) = map {
@@ -17,7 +15,7 @@ pub fn bif_maps_find_2(_vm: &vm::Machine, process: &RcProcess, args: &[Value]) -
             Some(value) => {
                 let heap = &process.context_mut().heap;
                 return Ok(tup2!(&heap, atom!(OK), value.clone()));
-            },
+            }
             None => {
                 return Ok(atom!(ERROR));
             }
@@ -26,7 +24,7 @@ pub fn bif_maps_find_2(_vm: &vm::Machine, process: &RcProcess, args: &[Value]) -
     Err(Exception::with_value(Reason::EXC_BADMAP, map.clone()))
 }
 
-pub fn bif_maps_get_2(_vm: &vm::Machine, process: &RcProcess, args: &[Value]) -> BifResult {
+pub fn bif_maps_get_2(_vm: &vm::Machine, process: &RcProcess, args: &[Term]) -> BifResult {
     let map = &args[0];
     if let Value::Map(m) = map {
         let hamt_map = &m.0;
@@ -34,7 +32,7 @@ pub fn bif_maps_get_2(_vm: &vm::Machine, process: &RcProcess, args: &[Value]) ->
         match hamt_map.find(target) {
             Some(value) => {
                 return Ok(value.clone());
-            },
+            }
             None => {
                 return Err(Exception::with_value(Reason::EXC_BADKEY, target.clone()));
             }
@@ -43,7 +41,7 @@ pub fn bif_maps_get_2(_vm: &vm::Machine, process: &RcProcess, args: &[Value]) ->
     Err(Exception::with_value(Reason::EXC_BADMAP, map.clone()))
 }
 
-pub fn bif_maps_from_list_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+pub fn bif_maps_from_list_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     if !args[0].is_list() {
         return Err(Exception::with_value(Reason::EXC_BADARG, args[0].clone()));
     }
@@ -67,36 +65,36 @@ pub fn bif_maps_from_list_1(_vm: &vm::Machine, _process: &RcProcess, args: &[Val
     Ok(Value::Map(value::Map(Arc::new(map))))
 }
 
-pub fn bif_maps_is_key_2(_vm: &vm::Machine, process: &RcProcess, args: &[Value]) -> BifResult {
+pub fn bif_maps_is_key_2(_vm: &vm::Machine, process: &RcProcess, args: &[Term]) -> BifResult {
     let map = &args[0];
     if let Value::Map(m) = map {
         let hamt_map = &m.0;
         let target = &args[1];
         let exist = hamt_map.find(target).is_some();
-        return Ok(Value::boolean(exist))
+        return Ok(Term::boolean(exist));
     }
     Err(Exception::with_value(Reason::EXC_BADMAP, map.clone()))
 }
 
-pub fn bif_maps_keys_1(_vm: &vm::Machine, process: &RcProcess, args: &[Value]) -> BifResult {
+pub fn bif_maps_keys_1(_vm: &vm::Machine, process: &RcProcess, args: &[Term]) -> BifResult {
     let map = &args[0];
     if let Value::Map(m) = map {
         let hamt_map = &m.0;
         let heap = &process.context_mut().heap;
-        let list = iter_to_list!(heap, hamt_map.iter().map(|(k,_)|k).cloned());
+        let list = iter_to_list!(heap, hamt_map.iter().map(|(k, _)| k).cloned());
         return Ok(list);
     }
     Err(Exception::with_value(Reason::EXC_BADMAP, map.clone()))
 }
 
-pub fn bif_maps_merge_2(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+pub fn bif_maps_merge_2(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     let map1 = match &args[0] {
         Value::Map(map) => &(*map.0),
-        _ => return Err(Exception::with_value(Reason::EXC_BADMAP, args[0].clone()))
+        _ => return Err(Exception::with_value(Reason::EXC_BADMAP, args[0].clone())),
     };
     let map2 = match &args[1] {
         Value::Map(map) => &(*map.0),
-        _ => return Err(Exception::with_value(Reason::EXC_BADMAP, args[1].clone()))
+        _ => return Err(Exception::with_value(Reason::EXC_BADMAP, args[1].clone())),
     };
     let mut new_map = map2.clone();
     for (k, v) in map1.iter() {
@@ -105,7 +103,7 @@ pub fn bif_maps_merge_2(_vm: &vm::Machine, _process: &RcProcess, args: &[Value])
     Ok(Value::Map(value::Map(Arc::new(new_map))))
 }
 
-pub fn bif_maps_put_3(_vm: &vm::Machine, process: &RcProcess, args: &[Value]) -> BifResult {
+pub fn bif_maps_put_3(_vm: &vm::Machine, process: &RcProcess, args: &[Term]) -> BifResult {
     let map = &args[0];
     let key = &args[1];
     let value = &args[2];
@@ -117,7 +115,7 @@ pub fn bif_maps_put_3(_vm: &vm::Machine, process: &RcProcess, args: &[Value]) ->
     Err(Exception::with_value(Reason::EXC_BADMAP, map.clone()))
 }
 
-pub fn bif_maps_remove_2(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+pub fn bif_maps_remove_2(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     let map = &args[0];
     let key = &args[1];
     if let Value::Map(m) = map {
@@ -128,8 +126,7 @@ pub fn bif_maps_remove_2(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]
     Err(Exception::with_value(Reason::EXC_BADMAP, map.clone()))
 }
 
-
-pub fn bif_maps_update_3(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]) -> BifResult {
+pub fn bif_maps_update_3(_vm: &vm::Machine, _process: &RcProcess, args: &[Term]) -> BifResult {
     let map = &args[0];
     let key = &args[1];
     let value = &args[2];
@@ -139,7 +136,7 @@ pub fn bif_maps_update_3(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]
             Some(_v) => {
                 let new_map = map.clone().plus(key.clone(), value.clone());
                 return Ok(Value::Map(value::Map(Arc::new(new_map))));
-            },
+            }
             None => {
                 return Err(Exception::with_value(Reason::EXC_BADKEY, key.clone()));
             }
@@ -149,12 +146,12 @@ pub fn bif_maps_update_3(_vm: &vm::Machine, _process: &RcProcess, args: &[Value]
     Err(Exception::with_value(Reason::EXC_BADMAP, map.clone()))
 }
 
-pub fn bif_maps_values_1(_vm: &vm::Machine, process: &RcProcess, args: &[Value]) -> BifResult {
+pub fn bif_maps_values_1(_vm: &vm::Machine, process: &RcProcess, args: &[Term]) -> BifResult {
     let map = &args[0];
     if let Value::Map(m) = map {
         let hamt_map = &m.0;
         let heap = &process.context_mut().heap;
-        let list = iter_to_list!(heap, hamt_map.iter().map(|(_,v)|v).cloned());
+        let list = iter_to_list!(heap, hamt_map.iter().map(|(_, v)| v).cloned());
         return Ok(list);
     }
     Err(Exception::with_value(Reason::EXC_BADMAP, map.clone()))
@@ -167,7 +164,11 @@ pub fn bif_maps_take_2(_vm: &vm::Machine, process: &RcProcess, args: &[Value]) -
         let result = if let Some(value) = (*m.0).find(key) {
             let new_map = (*m.0).clone().minus(key);
             let heap = &process.context_mut().heap;
-            tup2!(heap, value.clone(), Value::Map(value::Map(Arc::new(new_map))))
+            tup2!(
+                heap,
+                value.clone(),
+                Value::Map(value::Map(Arc::new(new_map)))
+            )
         } else {
             str_to_atom!("error")
         };
@@ -180,9 +181,10 @@ pub fn bif_maps_take_2(_vm: &vm::Machine, process: &RcProcess, args: &[Value]) -
 mod tests {
     use super::*;
     use crate::atom;
-    use crate::process::{self};
-    use crate::module;
     use crate::immix::Heap;
+    use crate::module;
+    use crate::process;
+    use hamt_rs::HamtMap;
 
     #[test]
     fn test_maps_find_2() {
@@ -191,7 +193,7 @@ mod tests {
         let process = process::allocate(&vm.state, module).unwrap();
 
         let key = str_to_atom!("test");
-        let map = map!(key.clone() => Value::Integer(3));
+        let map = map!(key.clone() => Term::int(3));
         let args = vec![key.clone(), map];
 
         let res = bif_maps_find_2(&vm, &process, &args);
@@ -200,10 +202,10 @@ mod tests {
         if let Ok(Value::Tuple(tuple)) = res {
             unsafe {
                 assert_eq!((*tuple).len, 2);
-                let slice: &[Value] = &(**tuple);
+                let slice: &[Term] = &(**tuple);
                 let mut iter = slice.iter();
                 assert_eq!(iter.next(), Some(&atom!(OK)));
-                assert_eq!(iter.next(), Some(&Value::Integer(3)));
+                assert_eq!(iter.next(), Some(&Term::int(3)));
             }
         } else {
             panic!();
@@ -217,7 +219,7 @@ mod tests {
         let process = process::allocate(&vm.state, module).unwrap();
 
         let key = str_to_atom!("test");
-        let map = map!(key.clone() => Value::Integer(3));
+        let map = map!(key.clone() => Term::int(3));
         let args = vec![str_to_atom!("fail"), map];
 
         let res = bif_maps_find_2(&vm, &process, &args);
@@ -247,12 +249,12 @@ mod tests {
         let module: *const module::Module = std::ptr::null();
         let process = process::allocate(&vm.state, module).unwrap();
 
-        let map = map!(str_to_atom!("test") => Value::Integer(3));
+        let map = map!(str_to_atom!("test") => Term::int(3));
         let args = vec![map, str_to_atom!("test")];
 
         let res = bif_maps_get_2(&vm, &process, &args);
 
-        assert_eq!(res, Ok(Value::Integer(3)));
+        assert_eq!(res, Ok(Term::int(3)));
     }
 
     #[test]
@@ -261,8 +263,8 @@ mod tests {
         let module: *const module::Module = std::ptr::null();
         let process = process::allocate(&vm.state, module).unwrap();
 
-        let bad_map = Value::Integer(3);
-        let args = vec![bad_map.clone(), Value::Atom(atom::from_str("test"))];
+        let bad_map = Term::int(3);
+        let args = vec![bad_map.clone(), Term::int(atom::from_str("test"))];
 
         if let Err(exception) = bif_maps_get_2(&vm, &process, &args) {
             assert_eq!(exception.reason, Reason::EXC_BADMAP);
@@ -278,7 +280,7 @@ mod tests {
         let module: *const module::Module = std::ptr::null();
         let process = process::allocate(&vm.state, module).unwrap();
 
-        let map = map!(str_to_atom!("test") => Value::Integer(3));
+        let map = map!(str_to_atom!("test") => Term::int(3));
         let args = vec![map, str_to_atom!("fail")];
 
         if let Err(exception) = bif_maps_get_2(&vm, &process, &args) {
@@ -296,9 +298,15 @@ mod tests {
         let process = process::allocate(&vm.state, module).unwrap();
 
         let heap = &Heap::new();
-        let list = cons!(heap,
-                         tup2!(heap, str_to_atom!("test"), Value::Integer(1)),
-                         cons!(heap, tup2!(heap, str_to_atom!("test2"), Value::Integer(2)), Value::Nil));
+        let list = cons!(
+            heap,
+            tup2!(heap, str_to_atom!("test"), Value::Integer(1)),
+            cons!(
+                heap,
+                tup2!(heap, str_to_atom!("test2"), Value::Integer(2)),
+                Value::Nil
+            )
+        );
         let args = vec![list];
         let res = bif_maps_from_list_1(&vm, &process, &args);
 
@@ -337,10 +345,21 @@ mod tests {
         let process = process::allocate(&vm.state, module).unwrap();
 
         let heap = &Heap::new();
-        let bad_tuple = tup3!(heap, Value::Integer(1), Value::Integer(2), Value::Integer(3));
-        let list = cons!(heap,
-                         bad_tuple.clone(),
-                         cons!(heap, tup2!(heap, str_to_atom!("test2"), Value::Integer(2)), Value::Nil));
+        let bad_tuple = tup3!(
+            heap,
+            Value::Integer(1),
+            Value::Integer(2),
+            Value::Integer(3)
+        );
+        let list = cons!(
+            heap,
+            bad_tuple.clone(),
+            cons!(
+                heap,
+                tup2!(heap, str_to_atom!("test2"), Value::Integer(2)),
+                Value::Nil
+            )
+        );
         let args = vec![list];
         let res = bif_maps_from_list_1(&vm, &process, &args);
 
@@ -358,12 +377,12 @@ mod tests {
         let module: *const module::Module = std::ptr::null();
         let process = process::allocate(&vm.state, module).unwrap();
 
-        let map = map!(str_to_atom!("test") => Value::Integer(1));
+        let map = map!(str_to_atom!("test") => Term::int(1));
         let args = vec![map, str_to_atom!("test")];
 
         let res = bif_maps_is_key_2(&vm, &process, &args);
 
-        assert_eq!(res, Ok(Value::boolean(true)));
+        assert_eq!(res, Ok(Term::boolean(true)));
     }
 
     #[test]
@@ -372,12 +391,12 @@ mod tests {
         let module: *const module::Module = std::ptr::null();
         let process = process::allocate(&vm.state, module).unwrap();
 
-        let map = map!(str_to_atom!("test") => Value::Integer(3));
+        let map = map!(str_to_atom!("test") => Term::int(3));
         let args = vec![map, str_to_atom!("false")];
 
         let res = bif_maps_is_key_2(&vm, &process, &args);
 
-        assert_eq!(res, Ok(Value::boolean(false)));
+        assert_eq!(res, Ok(Term::boolean(false)));
     }
 
     #[test]
@@ -386,7 +405,7 @@ mod tests {
         let module: *const module::Module = std::ptr::null();
         let process = process::allocate(&vm.state, module).unwrap();
 
-        let bad_map = Value::Integer(3);
+        let bad_map = Term::int(3);
         let args = vec![bad_map.clone(), str_to_atom!("test")];
 
         if let Err(exception) = bif_maps_is_key_2(&vm, &process, &args) {
@@ -403,7 +422,7 @@ mod tests {
         let module: *const module::Module = std::ptr::null();
         let process = process::allocate(&vm.state, module).unwrap();
 
-        let map = map!(str_to_atom!("test") => Value::Integer(1), str_to_atom!("test2") => Value::Integer(2));
+        let map = map!(str_to_atom!("test") => Term::int(1), str_to_atom!("test2") => Term::int(2));
         let args = vec![map];
 
         if let Ok(Value::List(cons)) = bif_maps_keys_1(&vm, &process, &args) {
@@ -428,7 +447,7 @@ mod tests {
         let module: *const module::Module = std::ptr::null();
         let process = process::allocate(&vm.state, module).unwrap();
 
-        let bad_map = Value::Integer(3);
+        let bad_map = Term::int(3);
         let args = vec![bad_map.clone(), str_to_atom!("test")];
 
         if let Err(exception) = bif_maps_keys_1(&vm, &process, &args) {
@@ -453,8 +472,14 @@ mod tests {
         if let Ok(Value::Map(body)) = res {
             assert_eq!(body.0.len(), 3);
             assert_eq!(body.0.find(&str_to_atom!("test")), Some(&Value::Integer(1)));
-            assert_eq!(body.0.find(&str_to_atom!("test2")), Some(&Value::Integer(2)));
-            assert_eq!(body.0.find(&str_to_atom!("test3")), Some(&Value::Integer(4)));
+            assert_eq!(
+                body.0.find(&str_to_atom!("test2")),
+                Some(&Value::Integer(2))
+            );
+            assert_eq!(
+                body.0.find(&str_to_atom!("test3")),
+                Some(&Value::Integer(4))
+            );
         } else {
             panic!();
         }
@@ -507,9 +532,13 @@ mod tests {
 
         let key = str_to_atom!("test");
 
-        let value = Value::Integer(2);
+        let value = Term::int(2);
         let map: value::HAMT = HamtMap::new();
-        let args = vec![Value::Map(value::Map(Arc::new(map))), key.clone(), value.clone()];
+        let args = vec![
+            Value::Map(value::Map(Arc::new(map))),
+            key.clone(),
+            value.clone(),
+        ];
 
         let res = bif_maps_put_3(&vm, &process, &args);
 
@@ -527,8 +556,8 @@ mod tests {
         let process = process::allocate(&vm.state, module).unwrap();
 
         let key = str_to_atom!("test");
-        let value = Value::Integer(2);
-        let bad_map = Value::Integer(3);
+        let value = Term::int(2);
+        let bad_map = Term::int(3);
         let args = vec![bad_map.clone(), key.clone(), value.clone()];
 
         let res = bif_maps_put_3(&vm, &process, &args);
@@ -548,7 +577,7 @@ mod tests {
         let process = process::allocate(&vm.state, module).unwrap();
 
         let key = str_to_atom!("test");
-        let map = map!(key.clone() => Value::Integer(1));
+        let map = map!(key.clone() => Term::int(1));
         let args = vec![map, key.clone()];
 
         let res = bif_maps_remove_2(&vm, &process, &args);
@@ -566,13 +595,13 @@ mod tests {
         let module: *const module::Module = std::ptr::null();
         let process = process::allocate(&vm.state, module).unwrap();
 
-        let args = vec![Value::Integer(1), Value::Integer(2)];
+        let args = vec![Term::int(1), Term::int(2)];
 
         let res = bif_maps_remove_2(&vm, &process, &args);
 
         if let Err(exception) = res {
             assert_eq!(exception.reason, Reason::EXC_BADMAP);
-            assert_eq!(exception.value, Value::Integer(1));
+            assert_eq!(exception.value, Term::int(1));
         } else {
             panic!();
         }
@@ -585,8 +614,8 @@ mod tests {
         let process = process::allocate(&vm.state, module).unwrap();
 
         let key = str_to_atom!("test");
-        let value = Value::Integer(1);
-        let update_value = Value::Integer(2);
+        let value = Term::int(1);
+        let update_value = Term::int(2);
         let map = map!(key.clone() => value.clone());
         let args = vec![map, key.clone(), update_value.clone()];
 
@@ -606,9 +635,13 @@ mod tests {
         let process = process::allocate(&vm.state, module).unwrap();
 
         let key = str_to_atom!("test");
-        let value = Value::Integer(2);
+        let value = Term::int(2);
         let map: value::HAMT = HamtMap::new();
-        let args = vec![Value::Map(value::Map(Arc::new(map))), key.clone(), value.clone()];
+        let args = vec![
+            Value::Map(value::Map(Arc::new(map))),
+            key.clone(),
+            value.clone(),
+        ];
 
         let res = bif_maps_update_3(&vm, &process, &args);
 
@@ -627,8 +660,8 @@ mod tests {
         let process = process::allocate(&vm.state, module).unwrap();
 
         let key = str_to_atom!("test");
-        let value = Value::Integer(2);
-        let bad_map = Value::Integer(3);
+        let value = Term::int(2);
+        let bad_map = Term::int(3);
         let args = vec![bad_map.clone(), key.clone(), value.clone()];
 
         let res = bif_maps_update_3(&vm, &process, &args);
@@ -647,16 +680,16 @@ mod tests {
         let module: *const module::Module = std::ptr::null();
         let process = process::allocate(&vm.state, module).unwrap();
 
-        let map = map!(str_to_atom!("test") => Value::Integer(1), str_to_atom!("test2") => Value::Integer(2));
+        let map = map!(str_to_atom!("test") => Term::int(1), str_to_atom!("test2") => Term::int(2));
         let args = vec![map];
 
         if let Ok(Value::List(cons)) = bif_maps_values_1(&vm, &process, &args) {
             unsafe {
                 let key1 = &(*cons).head;
-                assert_eq!(key1, &Value::Integer(1));
+                assert_eq!(key1, &Term::int(1));
                 if let Value::List(tail) = (*cons).tail {
                     let key2 = &(*tail).head;
-                    assert_eq!(key2, &Value::Integer(2));
+                    assert_eq!(key2, &Term::int(2));
                 } else {
                     panic!();
                 }
@@ -672,7 +705,7 @@ mod tests {
         let module: *const module::Module = std::ptr::null();
         let process = process::allocate(&vm.state, module).unwrap();
 
-        let bad_map = Value::Integer(3);
+        let bad_map = Term::int(3);
         let args = vec![bad_map.clone(), str_to_atom!("test")];
 
         if let Err(exception) = bif_maps_values_1(&vm, &process, &args) {
@@ -700,7 +733,10 @@ mod tests {
             assert_eq!(Value::Integer(2), iter.next().unwrap().clone());
             if let Value::Map(result_map) = iter.next().unwrap() {
                 assert_eq!(result_map.0.len(), 1);
-                assert_eq!(result_map.0.find(&str_to_atom!("test")), Some(&Value::Integer(1)));
+                assert_eq!(
+                    result_map.0.find(&str_to_atom!("test")),
+                    Some(&Value::Integer(1))
+                );
             } else {
                 panic!();
             }

--- a/src/bif/map.rs
+++ b/src/bif/map.rs
@@ -402,10 +402,13 @@ mod tests {
         let process = process::allocate(&vm.state, module).unwrap();
         let heap = &process.context_mut().heap;
 
-        let map = map!(heap, str_to_atom!("test") => Term::int(1), str_to_atom!("test2") => Term::int(2));
+        let map =
+            map!(heap, str_to_atom!("test") => Term::int(1), str_to_atom!("test2") => Term::int(2));
         let args = vec![map];
 
-        if let Ok(value::Cons { head, tail }) = bif_maps_keys_1(&vm, &process, &args).unwrap().try_into() {
+        if let Ok(value::Cons { head, tail }) =
+            bif_maps_keys_1(&vm, &process, &args).unwrap().try_into()
+        {
             unsafe {
                 let key1 = head;
                 assert_eq!(key1, &str_to_atom!("test"));
@@ -469,7 +472,8 @@ mod tests {
         let process = process::allocate(&vm.state, module).unwrap();
         let heap = &process.context_mut().heap;
 
-        let map = map!(heap, str_to_atom!("test") => Term::int(1), str_to_atom!("test2") => Term::int(2));
+        let map =
+            map!(heap, str_to_atom!("test") => Term::int(1), str_to_atom!("test2") => Term::int(2));
         let bad_map = Term::int(2);
 
         let args = vec![map.clone(), bad_map.clone()];
@@ -513,11 +517,7 @@ mod tests {
 
         let value = Term::int(2);
         let map: value::HAMT = HamtMap::new();
-        let args = vec![
-            Term::map(heap, map),
-            key.clone(),
-            value.clone(),
-        ];
+        let args = vec![Term::map(heap, map), key.clone(), value.clone()];
 
         let res = bif_maps_put_3(&vm, &process, &args);
 
@@ -619,11 +619,7 @@ mod tests {
         let key = str_to_atom!("test");
         let value = Term::int(2);
         let map: value::HAMT = HamtMap::new();
-        let args = vec![
-            Term::map(heap, map),
-            key.clone(),
-            value.clone(),
-        ];
+        let args = vec![Term::map(heap, map), key.clone(), value.clone()];
 
         let res = bif_maps_update_3(&vm, &process, &args);
 
@@ -663,10 +659,13 @@ mod tests {
         let process = process::allocate(&vm.state, module).unwrap();
         let heap = &process.context_mut().heap;
 
-        let map = map!(heap, str_to_atom!("test") => Term::int(1), str_to_atom!("test2") => Term::int(2));
+        let map =
+            map!(heap, str_to_atom!("test") => Term::int(1), str_to_atom!("test2") => Term::int(2));
         let args = vec![map];
 
-        if let Ok(value::Cons { head, tail }) = bif_maps_values_1(&vm, &process, &args).unwrap().try_into() {
+        if let Ok(value::Cons { head, tail }) =
+            bif_maps_values_1(&vm, &process, &args).unwrap().try_into()
+        {
             unsafe {
                 let key1 = head;
                 assert_eq!(key1, &Term::int(1));
@@ -706,7 +705,8 @@ mod tests {
         let process = process::allocate(&vm.state, module).unwrap();
         let heap = &process.context_mut().heap;
 
-        let map = map!(heap, str_to_atom!("test") => Term::int(1), str_to_atom!("test2") => Term::int(2));
+        let map =
+            map!(heap, str_to_atom!("test") => Term::int(1), str_to_atom!("test2") => Term::int(2));
         let key = str_to_atom!("test2");
         let args = vec![key.clone(), map.clone()];
 
@@ -717,10 +717,7 @@ mod tests {
             assert_eq!(Term::int(2), iter.next().unwrap().clone());
             if let Ok(value::Map { map, .. }) = iter.next().unwrap().try_into() {
                 assert_eq!(map.len(), 1);
-                assert_eq!(
-                    map.find(&str_to_atom!("test")),
-                    Some(&Term::int(1))
-                );
+                assert_eq!(map.find(&str_to_atom!("test")), Some(&Term::int(1)));
             } else {
                 panic!();
             }
@@ -755,7 +752,8 @@ mod tests {
         let process = process::allocate(&vm.state, module).unwrap();
         let heap = &process.context_mut().heap;
 
-        let map = map!(heap, str_to_atom!("test") => Term::int(1), str_to_atom!("test2") => Term::int(2));
+        let map =
+            map!(heap, str_to_atom!("test") => Term::int(1), str_to_atom!("test2") => Term::int(2));
         let key = str_to_atom!("test3");
         let args = vec![key.clone(), map.clone()];
 

--- a/src/bitstring.rs
+++ b/src/bitstring.rs
@@ -1,4 +1,4 @@
-use crate::value::Value;
+use crate::value::Term;
 use parking_lot::Mutex;
 use std::cmp::Ordering;
 use std::hash::{Hash, Hasher};
@@ -80,13 +80,13 @@ pub struct SubBinary {
     /// Is the underlying binary writable?
     is_writable: bool,
     /// Original binary (refc or heap)
-    original: Value,
+    original: Term,
 }
 
 // TODO: let's use nom to handle offsets & matches, and keep a reference to the binary
 pub struct MatchBuffer {
     /// Original binary
-    original: Value,
+    original: Term,
     /// Current position in binary
     base: usize,
     /// Offset in bits
@@ -99,7 +99,7 @@ pub struct MatchState<'a> {
     // TODO: wrap into value
     mb: MatchBuffer,
     /// Saved offsets, only valid for contexts created through bs_start_match2.
-    saved_offsets: &'a [Value],
+    saved_offsets: &'a [Term],
 }
 
 bitflags! {

--- a/src/bitstring.rs
+++ b/src/bitstring.rs
@@ -117,3 +117,18 @@ bitflags! {
         const BSF_NATIVE = 16;
     }
 }
+
+// Stores data on the process heap. Small, but expensive to copy.
+// HeapBin(len + ptr)
+// Stores data off the process heap, in an Arc<>. Cheap to copy around.
+// RefBin(Arc<String/Vec<u8?>>)
+// ^^ start with just RefBin since Rust already will do the String management for us
+// SubBin(len (original?), offset, bitsize,bitoffset,is_writable, orig_ptr -> Bin/RefBin)
+
+// consider using an Arc<RwLock<>> to make the inner string mutable? is the overhead worth it?
+// data is always append only, so maybe have an atomic bool for the writable bit and keep the
+// normal structure lockless.
+
+// bitstring is the base model, binary is an 8-bit aligned bitstring
+// https://www.reddit.com/r/rust/comments/2d7rrj/bit_level_pattern_matching/
+// https://docs.rs/bitstring/0.1.1/bitstring/bit_string/trait.BitString.html

--- a/src/etf.rs
+++ b/src/etf.rs
@@ -214,16 +214,16 @@ pub fn decode_string<'a>(rest: &'a [u8], heap: &Heap) -> IResult<&'a [u8], Term>
     }
 }
 
-pub fn decode_binary<'a>(rest: &'a [u8], _heap: &Heap) -> IResult<&'a [u8], Term> {
+pub fn decode_binary<'a>(rest: &'a [u8], heap: &Heap) -> IResult<&'a [u8], Term> {
     let (rest, len) = be_u32(rest)?;
     if len == 0 {
-        return Ok((rest, Term::Binary(Arc::new(bitstring::Binary::new()))));
+        return Ok((rest, Term::binary(heap, bitstring::Binary::new())));
     }
 
     let (rest, bytes) = take!(rest, len)?;
     Ok((
         rest,
-        Term::Binary(Arc::new(bitstring::Binary::from_vec(bytes.to_vec()))),
+        Term::binary(heap, bitstring::Binary::from_vec(bytes.to_vec())),
     ))
 }
 

--- a/src/exception.rs
+++ b/src/exception.rs
@@ -372,7 +372,7 @@ fn next_catch(process: &RcProcess) -> Option<InstrPtr> {
     // TODO: tracing instr handling here
 
     while ptr > 0 {
-        match context.stack[ptr - 1].try_into() {
+        match context.stack[ptr - 1].clone().try_into() {
             Ok(value::Boxed {
                 header: value::BOXED_CATCH,
                 value: ptr,
@@ -602,12 +602,12 @@ fn save_stacktrace(
     }
     // }
 
+    // Save the actual stack trace
+    erts_save_stacktrace(process, s, depth);
+
     // Package args and stack trace
     // c_p->ftrace = CONS(hp, args, make_big((Eterm *) s));
     exc.trace = cons!(heap, args, Term::from(boxed)); // TODO: need to cast S into something
-
-    // Save the actual stack trace
-    erts_save_stacktrace(process, s, depth)
 }
 
 fn erts_save_stacktrace(process: &RcProcess, s: &mut StackTrace, mut depth: u32) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,8 @@ mod macros;
 pub mod exception;
 #[macro_use]
 pub mod vm;
+#[macro_use]
+pub mod nanbox;
 mod atom;
 mod bif;
 mod bitstring;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,3 +31,7 @@ extern crate once_cell;
 
 #[macro_use]
 extern crate bitflags;
+
+#[cfg(test)]
+#[macro_use]
+extern crate quickcheck;

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -39,14 +39,14 @@ pub struct Loader<'a> {
 /// Compact term encoding values. BEAM does some tricks to be able to share the memory layout with
 /// regular values, but for the most part we don't need this (it also doesn't fit nanboxed values
 /// well).
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum LValue {
     // TODO: these dupe LTerm values
     Atom(u32),
     Integer(i64),
     Character(u8),
     Nil,
-    Binary(bitstring::Binary),
+    Binary(Arc<bitstring::Binary>),
     BigInt(BigInt),
     //
     Literal(u32),
@@ -344,7 +344,7 @@ impl<'a> Loader<'a> {
                         let bytes = &self.strings[offset..offset + len as usize];
                         let string = bytes.as_bytes().to_vec(); // TODO: check if most efficient
                         instruction.args =
-                            vec![LValue::Binary(bitstring::Binary::from_vec(string))];
+                            vec![LValue::Binary(Arc::new(bitstring::Binary::from_vec(string)))];
                         instruction
                     } else {
                         unreachable!()
@@ -364,15 +364,15 @@ impl<'a> Loader<'a> {
                     if *i == 0 {
                         return LValue::Nil;
                     }
-                    LValue::Atom(atom_map[&(i - 1)])
+                    LValue::Atom(atom_map[&(*i - 1)])
                 }
                 LValue::Label(l) => {
                     if *l == 0 {
                         return LValue::Label(0);
                     }
-                    LValue::Label(labels[l])
+                    LValue::Label(labels[&l])
                 }
-                val => *val.clone(),
+                val => val.clone()
             }
         };
 

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -5,7 +5,7 @@ use crate::immix::Heap;
 use crate::module::{Lambda, Module, MFA};
 use crate::opcodes::*;
 use crate::servo_arc::Arc;
-use crate::value::{Value, Term};
+use crate::value::Term;
 use compress::zlib;
 use hashbrown::HashMap;
 use nom::*;
@@ -744,7 +744,7 @@ fn parse_extended_literal(rest: &[u8]) -> IResult<&[u8], LValue> {
 #[derive(Debug)]
 pub struct Instruction {
     pub op: Opcode,
-    pub args: Vec<Term>,
+    pub args: Vec<LValue>,
 }
 
 named!(

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -371,7 +371,7 @@ impl<'a> Loader<'a> {
                     if *l == 0 {
                         return LValue::Label(0);
                     }
-                    LValue::Label(labels[&l])
+                    LValue::Label(labels[l])
                 }
                 val => val.clone(),
             }

--- a/src/loader.rs
+++ b/src/loader.rs
@@ -343,8 +343,9 @@ impl<'a> Loader<'a> {
                         let offset = offset as usize;
                         let bytes = &self.strings[offset..offset + len as usize];
                         let string = bytes.as_bytes().to_vec(); // TODO: check if most efficient
-                        instruction.args =
-                            vec![LValue::Binary(Arc::new(bitstring::Binary::from_vec(string)))];
+                        instruction.args = vec![LValue::Binary(Arc::new(
+                            bitstring::Binary::from_vec(string),
+                        ))];
                         instruction
                     } else {
                         unreachable!()
@@ -372,7 +373,7 @@ impl<'a> Loader<'a> {
                     }
                     LValue::Label(labels[&l])
                 }
-                val => val.clone()
+                val => val.clone(),
             }
         };
 

--- a/src/macros/arith.rs
+++ b/src/macros/arith.rs
@@ -24,7 +24,7 @@ macro_rules! integer_overflow_op {
     ) => {{
         // TODO: figure out if we can reduce amount of cloning here.
         match [$args[0].into_number(), $args[1].into_number()] {
-            [value::Num::Integer(rec), value::Num::Integer(arg)] => {
+            [Ok(value::Num::Integer(rec)), Ok(value::Num::Integer(arg))] => {
                 // Example: int + int -> int
                 //
                 // This will produce a bigint if the produced integer overflowed or
@@ -48,14 +48,14 @@ macro_rules! integer_overflow_op {
                     Term::int(result)
                 }
             }
-            [value::Num::Bignum(rec), value::Num::Integer(arg)] => {
+            [Ok(value::Num::Bignum(rec)), Ok(value::Num::Integer(arg))] => {
                 // Example: bigint + int -> bigint
 
                 let bigint = to_expr!(rec.$op(arg));
 
                 Term::bigint($heap, bigint)
             }
-            [value::Num::Integer(rec), value::Num::Bignum(arg)] => {
+            [Ok(value::Num::Integer(rec)), Ok(value::Num::Bignum(arg))] => {
                 // Example: int + bigint -> bigint
 
                 let rec = BigInt::from(rec);
@@ -63,7 +63,7 @@ macro_rules! integer_overflow_op {
 
                 Term::bigint($heap, bigint)
             }
-            [value::Num::Bignum(rec), value::Num::Bignum(arg)] => {
+            [Ok(value::Num::Bignum(rec)), Ok(value::Num::Bignum(arg))] => {
                 // Example: bigint + bigint -> bigint
 
                 let bigint = to_expr!(rec.$op(arg));

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -75,11 +75,11 @@ macro_rules! str_to_atom {
 // based off of maplit: https://github.com/bluss/maplit/blob/master/src/lib.rs
 #[macro_export]
 macro_rules! map {
-    (@single $($x:tt)*) => (());
+    // (@single $($x:tt)*) => (());
     //(@count $($rest:expr),*) => (<[()]>::len(&[$(map!(@single $rest)),*]));
 
-    ($($key:expr => $value:expr,)+) => { map!($($key => $value),+) };
-    ($($key:expr => $value:expr),*) => {
+    ($heap:expr, $($key:expr => $value:expr,)+) => { map!($heap, $($key => $value),+) };
+    ($heap:expr, $($key:expr => $value:expr),*) => {
         {
             // let _cap = map!(@count $($key),*);
             // let mut _map = ::std::collections::HashMap::with_capacity(_cap);
@@ -87,7 +87,7 @@ macro_rules! map {
             $(
                 _map = _map.plus($key, $value);
             )*
-            Value::Map(value::Map(Arc::new(_map)))
+            Term::map($heap, _map)
         }
     };
 }

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -52,7 +52,7 @@ macro_rules! bitstring {
     ($heap:expr, $str:expr) => {{
         let mut list = Term::nil();
         for char in $str.bytes().rev() {
-            list = cons!($heap, Value::Character(char), list);
+            list = cons!($heap, Term::int(char as i32), list);
         }
         list
     }};

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -52,7 +52,7 @@ macro_rules! bitstring {
     ($heap:expr, $str:expr) => {{
         let mut list = Term::nil();
         for char in $str.bytes().rev() {
-            list = cons!($heap, Term::int(char as i32), list);
+            list = cons!($heap, Term::int(i32::from(char)), list);
         }
         list
     }};

--- a/src/macros/mod.rs
+++ b/src/macros/mod.rs
@@ -8,7 +8,7 @@ macro_rules! tup2 {
             std::ptr::write(&mut tuple[0], $element1);
             std::ptr::write(&mut tuple[1], $element2);
         }
-        Value::Tuple(tuple)
+        Term::from(tuple)
     }};
 }
 
@@ -22,7 +22,7 @@ macro_rules! tup3 {
             std::ptr::write(&mut tuple[1], $element2);
             std::ptr::write(&mut tuple[2], $element3);
         }
-        Value::Tuple(tuple)
+        Term::from(tuple)
     }};
 }
 
@@ -36,7 +36,7 @@ macro_rules! tup4 {
             std::ptr::write(&mut tuple[2], $element3);
             std::ptr::write(&mut tuple[3], $element4);
         }
-        Value::Tuple(tuple)
+        Term::from(tuple)
     }};
 }
 
@@ -50,7 +50,7 @@ macro_rules! cons {
 #[macro_export]
 macro_rules! bitstring {
     ($heap:expr, $str:expr) => {{
-        let mut list = Value::Nil;
+        let mut list = Term::nil();
         for char in $str.bytes().rev() {
             list = cons!($heap, Value::Character(char), list);
         }
@@ -61,14 +61,14 @@ macro_rules! bitstring {
 #[macro_export]
 macro_rules! atom {
     ($const:ident) => {
-        Value::Atom(atom::$const)
+        Term::atom(atom::$const)
     };
 }
 
 #[macro_export]
 macro_rules! str_to_atom {
     ($str:expr) => {
-        Value::Atom(atom::from_str($str))
+        Term::atom(atom::from_str($str))
     };
 }
 
@@ -95,6 +95,6 @@ macro_rules! map {
 #[macro_export]
 macro_rules! iter_to_list {
     ($heap: expr, $iter:expr) => {
-        $iter.fold(Value::Nil, |res, val| value::cons($heap, val, res))
-    }
+        $iter.fold(Term::nil(), |res, val| value::cons($heap, val, res))
+    };
 }

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -1,14 +1,14 @@
-use crate::value::Value;
+use crate::value::Term;
 use parking_lot::Mutex;
 use std::collections::VecDeque;
 
 #[derive(Default)]
 pub struct Mailbox {
     /// Internal mailbox from which the process is safe to read.
-    internal: VecDeque<*const Value>,
+    internal: VecDeque<*const Term>,
 
     /// External mailbox, to which other processes can write (while holding the lock)
-    external: VecDeque<*const Value>,
+    external: VecDeque<*const Term>,
 
     /// Used for synchronizing writes to the external part.
     write_lock: Mutex<()>,
@@ -27,17 +27,17 @@ impl Mailbox {
         }
     }
 
-    pub fn send_external(&mut self, message: *const Value) {
+    pub fn send_external(&mut self, message: *const Term) {
         let _lock = self.write_lock.lock();
 
         self.external.push_back(message);
     }
 
-    pub fn send_internal(&mut self, message: *const Value) {
+    pub fn send_internal(&mut self, message: *const Term) {
         self.internal.push_back(message);
     }
 
-    pub fn receive(&mut self) -> Option<&*const Value> {
+    pub fn receive(&mut self) -> Option<&*const Term> {
         if self.internal.len() >= self.save {
             let _lock = self.write_lock.lock();
 

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -5,10 +5,10 @@ use std::collections::VecDeque;
 #[derive(Default)]
 pub struct Mailbox {
     /// Internal mailbox from which the process is safe to read.
-    internal: VecDeque<*const Term>,
+    internal: VecDeque<Term>,
 
     /// External mailbox, to which other processes can write (while holding the lock)
-    external: VecDeque<*const Term>,
+    external: VecDeque<Term>,
 
     /// Used for synchronizing writes to the external part.
     write_lock: Mutex<()>,
@@ -27,17 +27,17 @@ impl Mailbox {
         }
     }
 
-    pub fn send_external(&mut self, message: *const Term) {
+    pub fn send_external(&mut self, message: Term) {
         let _lock = self.write_lock.lock();
 
         self.external.push_back(message);
     }
 
-    pub fn send_internal(&mut self, message: *const Term) {
+    pub fn send_internal(&mut self, message: Term) {
         self.internal.push_back(message);
     }
 
-    pub fn receive(&mut self) -> Option<&*const Term> {
+    pub fn receive(&mut self) -> Option<&Term> {
         if self.internal.len() >= self.save {
             let _lock = self.write_lock.lock();
 

--- a/src/module.rs
+++ b/src/module.rs
@@ -3,7 +3,7 @@ use crate::exports_table::{ExportsTable, RcExportsTable};
 use crate::immix::Heap;
 use crate::loader::{FuncInfo, Instruction};
 use crate::process::InstrPtr;
-use crate::value::Value;
+use crate::value::Term;
 use crate::vm::Machine;
 use hashbrown::HashMap;
 
@@ -24,7 +24,7 @@ pub struct Lambda {
 pub struct Module {
     pub imports: Vec<MFA>, // mod,  func, arity
     pub exports: Vec<MFA>, // func, arity, label
-    pub literals: Vec<Value>,
+    pub literals: Vec<Term>,
     pub literal_heap: Heap,
     pub lambdas: Vec<Lambda>,
     pub funs: HashMap<(u32, u32), u32>, // (fun name as atom, arity) -> offset

--- a/src/nanbox.rs
+++ b/src/nanbox.rs
@@ -104,7 +104,6 @@ impl NanBoxable for i8 {
     }
 }
 
-
 impl NanBoxable for i16 {
     unsafe fn from_nan_box(n: NanBox) -> i16 {
         n.0 as i16
@@ -455,7 +454,6 @@ macro_rules! unsafe_make_nanbox {
         }
     }
 }
-
 
 #[cfg(test)]
 mod tests {

--- a/src/nanbox.rs
+++ b/src/nanbox.rs
@@ -34,7 +34,7 @@ pub trait NanBoxable: Sized {
 
         let shifted_tag = ((DOUBLE_MAX_TAG as u64) | (tag as u64)) << TAG_SHIFT;
         b.0 |= shifted_tag;
-        debug_assert!(b.tag() == u32::from(tag), "{} == {}", b.tag(), tag);
+        debug_assert!(b.tag() == tag, "{} == {}", b.tag(), tag);
         b
     }
 

--- a/src/nanbox.rs
+++ b/src/nanbox.rs
@@ -199,11 +199,11 @@ impl NanBox {
     }
 
     #[inline]
-    pub fn tag(self) -> u32 {
+    pub fn tag(self) -> u8 {
         if self.0 <= SHIFTED_DOUBLE_MAX_TAG {
             0
         } else {
-            (self.0 >> TAG_SHIFT) as u32 & !DOUBLE_MAX_TAG
+            ((self.0 >> TAG_SHIFT) as u32 & !DOUBLE_MAX_TAG) as u8
         }
     }
 }
@@ -303,7 +303,7 @@ impl<T> TypedNanBox<T> {
         self.nanbox.unpack()
     }
 
-    pub fn tag(&self) -> u32 {
+    pub fn tag(&self) -> u8 {
         self.nanbox.tag()
     }
 }

--- a/src/nanbox.rs
+++ b/src/nanbox.rs
@@ -1,0 +1,411 @@
+//! Defines the `unsafe_make_nanbox` macro which defines a type which packs values of different types
+//! into the unused space of the NaN representation of `f64`.
+
+use std::cmp::Ordering;
+use std::fmt;
+use std::marker::PhantomData;
+use std::mem;
+
+const TAG_SHIFT: u64 = 48;
+const DOUBLE_MAX_TAG: u32 = 0b11111_11111_11000_0;
+const SHIFTED_DOUBLE_MAX_TAG: u64 = ((DOUBLE_MAX_TAG as u64) << TAG_SHIFT) | 0xFFFFFFFF;
+
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+pub struct NanBox(u64);
+
+impl fmt::Debug for NanBox {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(
+            f,
+            "NanBox {{ tag: {:?}, payload: {:?} }}",
+            self.tag(),
+            self.0 & ((1 << TAG_SHIFT) - 1)
+        )
+    }
+}
+
+pub trait NanBoxable: Sized {
+    unsafe fn from_nan_box(n: NanBox) -> Self;
+
+    fn into_nan_box(self) -> NanBox;
+
+    fn pack_nan_box(self, tag: u8) -> NanBox {
+        let mut b = self.into_nan_box();
+
+        let shifted_tag = ((DOUBLE_MAX_TAG as u64) | (tag as u64)) << TAG_SHIFT;
+        b.0 |= shifted_tag;
+        debug_assert!(b.tag() == u32::from(tag), "{} == {}", b.tag(), tag);
+        b
+    }
+
+    unsafe fn unpack_nan_box(value: NanBox) -> Self {
+        let mask = (1 << TAG_SHIFT) - 1;
+        let b = NanBox(value.0 & mask);
+        Self::from_nan_box(b)
+    }
+}
+
+impl NanBoxable for f64 {
+    unsafe fn from_nan_box(n: NanBox) -> f64 {
+        mem::transmute(n)
+    }
+
+    fn into_nan_box(self) -> NanBox {
+        unsafe { NanBox(mem::transmute(self)) }
+    }
+
+    fn pack_nan_box(self, tag: u8) -> NanBox {
+        debug_assert!(tag == 0);
+        self.into_nan_box()
+    }
+
+    unsafe fn unpack_nan_box(value: NanBox) -> Self {
+        Self::from_nan_box(value)
+    }
+}
+
+macro_rules! impl_cast {
+    ($($typ: ident)+) => {
+        $(
+        impl NanBoxable for $typ {
+            unsafe fn from_nan_box(n: NanBox) -> $typ {
+                n.0 as $typ
+            }
+
+            fn into_nan_box(self) -> NanBox {
+                NanBox(self as u64)
+            }
+        }
+        )*
+    }
+}
+
+impl_cast! { u8 u16 u32 i8 i16 i32 }
+
+impl NanBoxable for char {
+    unsafe fn from_nan_box(n: NanBox) -> char {
+        std::char::from_u32_unchecked(n.0 as u32)
+    }
+
+    fn into_nan_box(self) -> NanBox {
+        NanBox(self as u64)
+    }
+}
+
+impl<'a, T> NanBoxable for &'a T {
+    unsafe fn from_nan_box(n: NanBox) -> Self {
+        &*(n.0 as *const T)
+    }
+
+    fn into_nan_box(self) -> NanBox {
+        NanBox(self as *const T as u64)
+    }
+}
+
+impl<'a, T> NanBoxable for Option<&'a T> {
+    unsafe fn from_nan_box(n: NanBox) -> Self {
+        (n.0 as *const T).as_ref()
+    }
+
+    fn into_nan_box(self) -> NanBox {
+        use std::ptr::null;
+        (match self {
+            Some(p) => p as *const T,
+            None => null(),
+        })
+        .into_nan_box()
+    }
+}
+
+macro_rules! impl_array {
+    ($($typ: ty)+) => {
+        $(
+        impl NanBoxable for $typ {
+            unsafe fn from_nan_box(n: NanBox) -> Self {
+                use std::ptr::copy_nonoverlapping;
+                use std::mem::size_of;
+                debug_assert!(size_of::<Self>() <= 6);
+                let mut result = Self::default();
+                copy_nonoverlapping(
+                    &n as *const NanBox as *const _,
+                    result.as_mut_ptr(),
+                    result.len());
+                result
+            }
+
+            fn into_nan_box(self) -> NanBox {
+                unsafe {
+                    use std::ptr::copy_nonoverlapping;
+                    use std::mem::size_of;
+                    debug_assert!(size_of::<Self>() <= 6);
+                    let mut result = NanBox(0);
+                    copy_nonoverlapping(
+                        self.as_ptr(),
+                        &mut result as *mut NanBox as *mut _,
+                        self.len());
+                    result
+                }
+            }
+        }
+        )*
+    }
+}
+
+impl_array! { [u8; 1] [u8; 2] [u8; 3] [u8; 4] [u8; 5] [u8; 6] }
+impl_array! { [i8; 1] [i8; 2] [i8; 3] [i8; 4] [i8; 5] [i8; 6] }
+impl_array! { [i16; 1] [i16; 2] [i16; 3] }
+impl_array! { [u16; 1] [u16; 2] [u16; 3] }
+impl_array! { [i32; 1] }
+impl_array! { [u32; 1] }
+impl_array! { [f32; 1] }
+
+macro_rules! impl_cast_t {
+    ($param: ident, $($typ: ty)+) => {
+        $(
+        impl<$param> NanBoxable for $typ {
+            unsafe fn from_nan_box(n: NanBox) -> $typ {
+                n.0 as $typ
+            }
+
+            fn into_nan_box(self) -> NanBox {
+                debug_assert!((self as u64) >> TAG_SHIFT == 0);
+                NanBox(self as u64)
+            }
+        }
+        )*
+    }
+}
+
+impl_cast_t! { T, *mut T *const T }
+
+impl NanBox {
+    pub unsafe fn new<T>(tag: u8, value: T) -> NanBox
+    where
+        T: NanBoxable,
+    {
+        debug_assert!(
+            tag < 1 << 4,
+            "Nanboxes must have tags smaller than {}",
+            1 << 4
+        );
+        value.pack_nan_box(tag)
+    }
+
+    pub unsafe fn unpack<T>(self) -> T
+    where
+        T: NanBoxable,
+    {
+        T::unpack_nan_box(self)
+    }
+
+    #[inline]
+    pub fn tag(self) -> u32 {
+        if self.0 <= SHIFTED_DOUBLE_MAX_TAG {
+            0
+        } else {
+            (self.0 >> TAG_SHIFT) as u32 & !DOUBLE_MAX_TAG
+        }
+    }
+}
+
+pub struct TypedNanBox<T> {
+    nanbox: NanBox,
+    _marker: PhantomData<T>,
+}
+
+impl<T> Copy for TypedNanBox<T> where T: From<TypedNanBox<T>> + Into<TypedNanBox<T>> + Copy {}
+
+impl<T> Clone for TypedNanBox<T>
+where
+    T: From<TypedNanBox<T>> + Into<TypedNanBox<T>> + Clone,
+{
+    fn clone(&self) -> Self {
+        T::from(TypedNanBox {
+            nanbox: self.nanbox,
+            _marker: PhantomData,
+        })
+        //.clone()
+        .into()
+    }
+}
+
+impl<T> fmt::Debug for TypedNanBox<T>
+where
+    T: From<TypedNanBox<T>> + Into<TypedNanBox<T>> + fmt::Debug + Clone,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{:?}", T::from(self.clone()))
+    }
+}
+
+impl<T> fmt::Display for TypedNanBox<T>
+where
+    T: From<TypedNanBox<T>> + Into<TypedNanBox<T>> + fmt::Display + Clone,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", T::from(self.clone()))
+    }
+}
+
+impl<T> PartialEq for TypedNanBox<T>
+where
+    T: From<TypedNanBox<T>> + Into<TypedNanBox<T>> + PartialEq<T> + Clone,
+{
+    fn eq(&self, other: &TypedNanBox<T>) -> bool {
+        T::from(self.clone()) == T::from(other.clone())
+    }
+}
+
+impl<T> Eq for TypedNanBox<T> where T: From<TypedNanBox<T>> + Into<TypedNanBox<T>> + Eq + Clone {}
+
+impl<T> PartialOrd for TypedNanBox<T>
+where
+    T: From<TypedNanBox<T>> + Into<TypedNanBox<T>> + PartialOrd<T> + Clone,
+{
+    fn partial_cmp(&self, other: &TypedNanBox<T>) -> Option<Ordering> {
+        T::from(self.clone()).partial_cmp(&T::from(other.clone()))
+    }
+}
+
+impl<T> Ord for TypedNanBox<T>
+where
+    T: From<TypedNanBox<T>> + Into<TypedNanBox<T>> + Ord + Clone,
+{
+    fn cmp(&self, other: &TypedNanBox<T>) -> Ordering {
+        T::from(self.clone()).cmp(&T::from(other.clone()))
+    }
+}
+
+impl<T> From<T> for TypedNanBox<T>
+where
+    T: From<TypedNanBox<T>>,
+{
+    fn from(value: T) -> TypedNanBox<T> {
+        value.into()
+    }
+}
+
+impl<T> TypedNanBox<T> {
+    pub unsafe fn new<U>(tag: u8, value: U) -> TypedNanBox<T>
+    where
+        U: NanBoxable,
+    {
+        TypedNanBox {
+            nanbox: NanBox::new(tag, value),
+            _marker: PhantomData,
+        }
+    }
+
+    pub unsafe fn unpack<U>(self) -> U
+    where
+        U: NanBoxable,
+    {
+        self.nanbox.unpack()
+    }
+
+    pub fn tag(&self) -> u32 {
+        self.nanbox.tag()
+    }
+}
+
+/// Creates an `enum` which is packed into the signaling NaN representation of `f64`.
+///
+/// Some limitations apply to make this work in a safe manner.
+///
+/// * The first and only the first variant must hold a `f64`.
+/// * There must be 8 or fewer variants in the defined enum (this is only checked with
+///   `debug_assert!`)
+/// * Pointers stored in a nanbox must only use the lower 48 bits (checked via `debug_assert!` only).
+///
+
+#[cfg(test)]
+#[macro_use]
+extern crate quickcheck;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::f64;
+    use std::fmt;
+
+    use quickcheck::TestResult;
+
+    fn test_eq<T>(l: T, r: T) -> TestResult
+    where
+        T: PartialEq + fmt::Debug,
+    {
+        if l == r {
+            TestResult::passed()
+        } else {
+            TestResult::error(format!("{:?} != {:?}", l, r))
+        }
+    }
+
+    quickcheck! {
+        fn nanbox_f64(f: f64) -> TestResult {
+            unsafe {
+                test_eq(NanBox::new(0, f).unpack(), f)
+            }
+        }
+
+        fn nanbox_u32(tag: u8, v: u32) -> TestResult {
+            if tag == 0 || tag >= 8 {
+                return TestResult::discard();
+            }
+            unsafe {
+                TestResult::from_bool(NanBox::new(tag, v).tag() == tag as u32)
+            }
+        }
+
+        fn nanbox_ptr(tag: u8, v: u32) -> TestResult {
+            if tag == 0 || tag >= 8 {
+                return TestResult::discard();
+            }
+            unsafe {
+                let nanbox = NanBox::new(tag, Box::into_raw(Box::new(v)));
+                TestResult::from_bool(nanbox.tag() == tag as u32)
+            }
+        }
+    }
+
+    unsafe_make_nanbox! {
+        #[derive(Clone, Debug, PartialEq)]
+        pub enum Value, Variant {
+            Float(f64),
+            Int(i32),
+            Pointer(*mut ()),
+            Array([u8; 6])
+        }
+    }
+
+    #[test]
+    fn box_test() {
+        assert_eq!(Value::from(123).into_variant(), Variant::Int(123));
+        assert_eq!(
+            Value::from(3000 as *mut ()).into_variant(),
+            Variant::Pointer(3000 as *mut ())
+        );
+        assert_eq!(Value::from(3.14).into_variant(), Variant::Float(3.14));
+
+        let array = [1, 2, 3, 4, 5, 6];
+        assert_eq!(Value::from(array).into_variant(), Variant::Array(array));
+
+        let array = [255, 255, 255, 255, 255, 255];
+        assert_eq!(Value::from(array).into_variant(), Variant::Array(array));
+    }
+
+    #[test]
+    fn nan_box_nan() {
+        match Value::from(f64::NAN).into_variant() {
+            Variant::Float(x) => assert!(x.is_nan()),
+            x => panic!("Unexpected {:?}", x),
+        }
+    }
+
+    #[should_panic]
+    #[test]
+    fn invalid_pointer() {
+        ((1u64 << TAG_SHIFT) as *const ()).into_nan_box();
+    }
+}

--- a/src/nanbox.rs
+++ b/src/nanbox.rs
@@ -262,10 +262,10 @@ where
     T: From<TypedNanBox<T>> + Into<TypedNanBox<T>> + Clone,
 {
     fn clone(&self) -> Self {
-        Self::from(TypedNanBox {
+        Self {
             nanbox: self.nanbox,
             _marker: PhantomData,
-        })
+        }
     }
 }
 

--- a/src/numeric/division.rs
+++ b/src/numeric/division.rs
@@ -16,6 +16,26 @@ pub trait OverflowingFlooredDiv<RHS = Self> {
     fn overflowing_floored_division(self, rhs: RHS) -> (Self::Output, bool);
 }
 
+impl FlooredDiv for i32 {
+    type Output = i32;
+
+    fn floored_division(self, rhs: Self) -> Self::Output {
+        num_integer::div_floor(self, rhs)
+    }
+}
+
+impl OverflowingFlooredDiv for i32 {
+    type Output = i32;
+
+    fn overflowing_floored_division(self, rhs: Self) -> (Self::Output, bool) {
+        if self == Self::min_value() && rhs == -1 {
+            (self, true)
+        } else {
+            (self.floored_division(rhs), false)
+        }
+    }
+}
+
 impl FlooredDiv for i64 {
     type Output = i64;
 

--- a/src/numeric/modulo.rs
+++ b/src/numeric/modulo.rs
@@ -16,6 +16,26 @@ pub trait OverflowingModulo<RHS = Self> {
     fn overflowing_modulo(self, rhs: RHS) -> (Self::Output, bool);
 }
 
+impl Modulo for i32 {
+    type Output = i32;
+
+    fn modulo(self, rhs: Self) -> Self::Output {
+        ((self % rhs) + rhs) % rhs
+    }
+}
+
+impl OverflowingModulo for i32 {
+    type Output = i32;
+
+    fn overflowing_modulo(self, rhs: Self) -> (Self::Output, bool) {
+        if self == Self::min_value() && rhs == -1 {
+            (0, true)
+        } else {
+            (self.modulo(rhs), false)
+        }
+    }
+}
+
 impl Modulo for i64 {
     type Output = i64;
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -185,7 +185,6 @@ impl TryInto<value::Boxed<InstrPtr>> for Term {
     }
 }
 
-
 impl ExecutionContext {
     pub fn new(module: *const Module) -> ExecutionContext {
         unsafe {

--- a/src/process.rs
+++ b/src/process.rs
@@ -60,13 +60,15 @@ bitflags! {
 impl ExecutionContext {
     #[inline]
     // TODO: expand_arg should return by value
-    pub fn expand_arg<'a>(&'a self, arg: &'a LValue) -> &'a Term {
+    pub fn expand_arg(&self, arg: &LValue) -> Term {
         match arg {
             // TODO: optimize away into a reference somehow at load time
-            LValue::ExtendedLiteral(i) => unsafe { &(*self.ip.module).literals[*i as usize] },
-            LValue::X(i) => &self.x[*i as usize],
-            LValue::Y(i) => &self.stack[self.stack.len() - (*i + 2) as usize],
-            //LValue::Integer(i) => &Term::int(*i as i32), // TODO: make LValue i32
+            LValue::ExtendedLiteral(i) => unsafe { (*self.ip.module).literals[*i as usize] },
+            LValue::X(i) => self.x[*i as usize],
+            LValue::Y(i) => self.stack[self.stack.len() - (*i + 2) as usize],
+            LValue::Integer(i) => Term::int(*i as i32), // TODO: make LValue i32
+            LValue::Atom(i) => Term::atom(*i),
+            LValue::Nil => Term::nil(),
             value => unimplemented!("expand unimplemented for {:?}", value),
         }
     }

--- a/src/process.rs
+++ b/src/process.rs
@@ -5,7 +5,7 @@ use crate::mailbox::Mailbox;
 use crate::module::{Module, MFA};
 use crate::pool::Job;
 pub use crate::process_table::PID;
-use crate::value::{Term, HAMT};
+use crate::value::Term;
 use crate::vm::RcState;
 use hashbrown::HashMap;
 use std::cell::UnsafeCell;
@@ -181,7 +181,7 @@ pub struct LocalData {
     pub thread_id: Option<u8>,
 
     /// A [process dictionary](https://www.erlang.org/course/advanced#dict)
-    pub dictionary: HAMT,
+    pub dictionary: HashMap<Term, Term>,
 }
 
 pub struct Process {
@@ -296,7 +296,7 @@ pub fn spawn(
     let new_proc = allocate(state, module)?;
     let new_pid = new_proc.pid;
     // let pid_ptr = new_proc.allocate_usize(new_pid, state.integer_prototype);
-    let pid_ptr = Value::Pid(new_pid);
+    let pid_ptr = Term::pid(new_pid);
 
     let context = new_proc.context_mut();
 
@@ -305,7 +305,7 @@ pub fn spawn(
     let mut i = 0;
     unsafe {
         let mut cons = &args;
-        while let Value::List(ptr) = *cons {
+        while let Term::List(ptr) = *cons {
             context.x[i] = (*ptr).head.clone();
             i += 1;
             cons = &(*ptr).tail;

--- a/src/process.rs
+++ b/src/process.rs
@@ -65,6 +65,7 @@ impl ExecutionContext {
             LValue::ExtendedLiteral(i) => unsafe { &(*self.ip.module).literals[*i as usize] },
             LValue::X(i) => &self.x[*i as usize],
             LValue::Y(i) => &self.stack[self.stack.len() - (*i + 2) as usize],
+            //LValue::Integer(i) => &Term::int(*i as i32), // TODO: make LValue i32
             value => unimplemented!("expand unimplemented for {:?}", value),
         }
     }

--- a/src/process.rs
+++ b/src/process.rs
@@ -1,5 +1,6 @@
 use crate::exception::{Exception, Reason};
 use crate::immix::Heap;
+use crate::loader::LValue;
 use crate::loader::{FuncInfo, LINE_INVALID_LOCATION};
 use crate::mailbox::Mailbox;
 use crate::module::{Module, MFA};
@@ -53,6 +54,19 @@ bitflags! {
     pub struct Flag: u32 {
         const INITIAL = 0;
         const TRAP_EXIT = (1 << 0);
+    }
+}
+
+impl ExecutionContext {
+    #[inline]
+    pub fn expand_arg<'a>(&'a self, arg: &'a LValue) -> &'a Term {
+        match arg {
+            // TODO: optimize away into a reference somehow at load time
+            LValue::ExtendedLiteral(i) => unsafe { &(*self.ip.module).literals[*i as usize] },
+            LValue::X(i) => &self.x[*i as usize],
+            LValue::Y(i) => &self.stack[self.stack.len() - (*i + 2) as usize],
+            value => unimplemented!("expand unimplemented for {:?}", value),
+        }
     }
 }
 

--- a/src/process.rs
+++ b/src/process.rs
@@ -149,6 +149,42 @@ impl InstrPtr {
     }
 }
 
+// TODO: these are kinda messy since Opt<ptr> vs ptr deboxes differently
+
+// TODO: to be TryFrom once rust stabilizes the trait
+impl TryInto<value::Boxed<Option<InstrPtr>>> for Term {
+    type Error = value::WrongBoxError;
+
+    #[inline]
+    fn try_into(&self) -> Result<&value::Boxed<Option<InstrPtr>>, value::WrongBoxError> {
+        if let value::Variant::Pointer(ptr) = self.into_variant() {
+            unsafe {
+                if *ptr == value::BOXED_CP {
+                    return Ok(&*(ptr as *const value::Boxed<Option<InstrPtr>>));
+                }
+            }
+        }
+        Err(value::WrongBoxError)
+    }
+}
+// TODO: to be TryFrom once rust stabilizes the trait
+impl TryInto<value::Boxed<InstrPtr>> for Term {
+    type Error = value::WrongBoxError;
+
+    #[inline]
+    fn try_into(&self) -> Result<&value::Boxed<InstrPtr>, value::WrongBoxError> {
+        if let value::Variant::Pointer(ptr) = self.into_variant() {
+            unsafe {
+                if *ptr == value::BOXED_CATCH {
+                    return Ok(&*(ptr as *const value::Boxed<InstrPtr>));
+                }
+            }
+        }
+        Err(value::WrongBoxError)
+    }
+}
+
+
 impl ExecutionContext {
     pub fn new(module: *const Module) -> ExecutionContext {
         unsafe {

--- a/src/process_registry.rs
+++ b/src/process_registry.rs
@@ -1,7 +1,7 @@
+use crate::process::PID;
+use crate::servo_arc::Arc;
 use hashbrown::HashMap;
 use parking_lot::Mutex;
-use crate::servo_arc::Arc;
-use crate::process::PID;
 
 // pub type RcProcessRegistry = Arc<Mutex<ProcessRegistry<RcProcess>>>;
 
@@ -85,7 +85,7 @@ impl<T: Clone> ProcessRegistry<T> {
 //     }
 
 //     r.name = name;
-    
+
 //     rp = (RegProc*) hash_put(&process_reg, (void*) &r);
 //     if (proc && rp->p == proc) {
 // 	if (IS_TRACED_FL(proc, F_TRACE_PROCS)) {

--- a/src/value.rs
+++ b/src/value.rs
@@ -391,46 +391,53 @@ impl Term {
     // immediates
 
     #[inline]
-    pub fn is_none(&self) -> bool {
+    pub fn is_none(self) -> bool {
         self.value.tag() as u8 == TERM_NIL // TODO
     }
 
-    pub fn is_float(&self) -> bool {
+    #[inline]
+    pub fn is_float(self) -> bool {
         self.value.tag() as u8 == TERM_FLOAT
     }
 
-    pub fn is_nil(&self) -> bool {
+    #[inline]
+    pub fn is_nil(self) -> bool {
         self.value.tag() as u8 == TERM_NIL
     }
 
-    pub fn is_smallint(&self) -> bool {
+    #[inline]
+    pub fn is_smallint(self) -> bool {
         self.value.tag() as u8 == TERM_INTEGER
     }
 
-    pub fn is_atom(&self) -> bool {
+    #[inline]
+    pub fn is_atom(self) -> bool {
         self.value.tag() as u8 == TERM_ATOM
     }
 
-    pub fn is_port(&self) -> bool {
+    #[inline]
+    pub fn is_port(self) -> bool {
         self.value.tag() as u8 == TERM_PORT
     }
 
-    pub fn is_pid(&self) -> bool {
+    #[inline]
+    pub fn is_pid(self) -> bool {
         self.value.tag() as u8 == TERM_PID
     }
 
-    pub fn is_pointer(&self) -> bool {
+    #[inline]
+    pub fn is_pointer(self) -> bool {
         self.value.tag() as u8 == TERM_POINTER
     }
 
     #[inline]
-    pub fn is_list(&self) -> bool {
+    pub fn is_list(self) -> bool {
         let tag = self.value.tag() as u8;
         tag == TERM_CONS || tag == TERM_NIL
     }
 
     #[inline]
-    pub fn get_type(&self) -> Type {
+    pub fn get_type(self) -> Type {
         match self.value.tag() as u8 {
             TERM_FLOAT => Type::Number,
             TERM_NIL => Type::Nil,
@@ -454,7 +461,7 @@ impl Term {
         }
     }
 
-    pub fn get_boxed_header(&self) -> Header {
+    pub fn get_boxed_header(self) -> Header {
         if let Variant::Pointer(ptr) = self.into_variant() {
             unsafe { return *ptr }
         }
@@ -476,7 +483,7 @@ impl Term {
     }
 
     /// A method that's optimized for retrieving number types.
-    pub fn into_number(&self) -> Result<Num, ()> {
+    pub fn into_number(self) -> Result<Num, ()> {
         match self.into_variant() {
             Variant::Integer(i) => Ok(Num::Integer(i)),
             Variant::Float(self::Float(i)) => Ok(Num::Float(i)),
@@ -494,7 +501,7 @@ impl Term {
     }
 
     // TODO: ExtendedList should instead become a Term vec
-    pub fn into_lvalue(&self) -> loader::LValue {
+    pub fn into_lvalue(self) -> loader::LValue {
         match self.into_variant() {
             Variant::Integer(i) => loader::LValue::Integer(i64::from(i)),
             Variant::Atom(i) => loader::LValue::Atom(i),
@@ -507,9 +514,9 @@ impl Term {
     // ------
 
     #[inline]
-    pub fn is_integer(&self) -> bool {
+    pub fn is_integer(self) -> bool {
         match self.into_variant() {
-            Variant::Integer(i) => true,
+            Variant::Integer(_) => true,
             Variant::Pointer(ptr) => unsafe {
                 match *ptr {
                     BOXED_BIGINT => true,
@@ -521,21 +528,21 @@ impl Term {
     }
 
     #[inline]
-    pub fn is_number(&self) -> bool {
+    pub fn is_number(self) -> bool {
         self.get_type() == Type::Number
     }
 
     #[inline]
-    pub fn is_ref(&self) -> bool {
+    pub fn is_ref(self) -> bool {
         self.get_type() == Type::Ref
     }
 
-    pub fn is_binary(&self) -> bool {
+    pub fn is_binary(self) -> bool {
         self.get_type() == Type::Binary
     }
 
     #[inline]
-    pub fn is_non_empty_list(&self) -> bool {
+    pub fn is_non_empty_list(self) -> bool {
         match self.into_variant() {
             Variant::Cons(ptr) => unsafe { !(*ptr).head.is_nil() },
             _ => false,
@@ -543,17 +550,17 @@ impl Term {
     }
 
     #[inline]
-    pub fn is_tuple(&self) -> bool {
+    pub fn is_tuple(self) -> bool {
         self.get_type() == Type::Tuple
     }
 
     #[inline]
-    pub fn is_function(&self) -> bool {
+    pub fn is_function(self) -> bool {
         self.get_type() == Type::Closure
     }
 
     #[inline]
-    pub fn is_boolean(&self) -> bool {
+    pub fn is_boolean(self) -> bool {
         match self.into_variant() {
             Variant::Atom(atom::TRUE) | Variant::Atom(atom::FALSE) => true,
             _ => false,
@@ -561,16 +568,16 @@ impl Term {
     }
 
     #[inline]
-    pub fn is_map(&self) -> bool {
+    pub fn is_map(self) -> bool {
         self.get_type() == Type::Map
     }
 
     #[inline]
-    pub fn is_cp(&self) -> bool {
+    pub fn is_cp(self) -> bool {
         self.get_type() == Type::CP
     }
 
-    pub fn to_u32(&self) -> u32 {
+    pub fn to_u32(self) -> u32 {
         match self.into_variant() {
             Variant::Atom(i) => i,
             Variant::Pid(i) => i,
@@ -588,7 +595,7 @@ impl Term {
 
     pub fn erl_partial_cmp(&self, other: &Self) -> Option<Ordering> {
         // TODO: loosely compare int and floats
-        Some(self.cmp(&other))
+        Some(self.cmp(other))
     }
 }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -136,6 +136,12 @@ impl From<&mut Map> for Term {
     }
 }
 
+impl From<&mut Bignum> for Term {
+    fn from(value: &mut Bignum) -> Term {
+        Term::from(Variant::Pointer(value as *const Bignum as *const Header))
+    }
+}
+
 impl From<Variant> for Term {
     fn from(value: Variant) -> Term {
         unsafe {
@@ -307,6 +313,13 @@ impl Term {
         Term::from(heap.alloc(self::Map {
             header: BOXED_MAP,
             map,
+        }))
+    }
+
+    pub fn bigint(heap: &Heap, value: BigInt) -> Self {
+        Term::from(heap.alloc(self::Bignum {
+            header: BOXED_BIGINT,
+            value,
         }))
     }
 

--- a/src/value.rs
+++ b/src/value.rs
@@ -271,6 +271,12 @@ pub enum Type {
     Binary,
 }
 
+pub enum Num {
+    Float(f64),
+    Integer(i32),
+    Bignum(BigInt)
+}
+
 impl Term {
     #[inline]
     pub fn nil() -> Self {
@@ -388,6 +394,21 @@ impl Term {
             unsafe { return &mut *(ptr as *mut T) }
         }
         panic!("Not a boxed type!")
+    }
+
+    /// A method that's optimized for retrieving number types.
+    pub fn into_number(&self) -> Num {
+        match self.into_variant() {
+            Variant::Integer(i) => Num::Integer(i),
+            Variant::Float(i) => Num::Float(i),
+            Variant::Pointer(ptr) => unsafe {
+                match *ptr {
+                    BOXED_BIGINT => return &*(ptr as *const BigInt),
+                    _ => panic!("invalid type!")
+                }
+            }
+            _ => panic!("invalid type!"),
+        }
     }
 
     // ------

--- a/src/value/closure.rs
+++ b/src/value/closure.rs
@@ -1,0 +1,27 @@
+use crate::module;
+use crate::value::{Boxed, Term, TryInto, Variant, WrongBoxError, BOXED_CLOSURE};
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct Closure {
+    pub ptr: u32,
+    pub mfa: module::MFA,
+    pub binding: Option<Vec<Term>>,
+}
+
+// TODO: to be TryFrom once rust stabilizes the trait
+impl TryInto<Boxed<Closure>> for Term {
+    type Error = WrongBoxError;
+
+    #[inline]
+    fn try_into(&self) -> Result<&Boxed<Closure>, WrongBoxError> {
+        if let Variant::Pointer(ptr) = self.into_variant() {
+            unsafe {
+                if *ptr == BOXED_CLOSURE {
+                    return Ok(&*(ptr as *const Boxed<Closure>));
+                }
+            }
+        }
+        Err(WrongBoxError)
+    }
+}

--- a/src/value/cons.rs
+++ b/src/value/cons.rs
@@ -1,6 +1,6 @@
-use super::{Term, Variant, WrongBoxError, TryInto};
-use std::ptr::NonNull;
+use super::{Term, TryInto, Variant, WrongBoxError};
 use core::marker::PhantomData;
+use std::ptr::NonNull;
 
 #[derive(Debug)]
 #[repr(C)]
@@ -13,10 +13,7 @@ unsafe impl Sync for Cons {}
 
 impl PartialEq for Cons {
     fn eq(&self, other: &Self) -> bool {
-        self
-            .iter()
-            .zip(other.iter())
-            .all(|(e1, e2)| e1.eq(e2))
+        self.iter().zip(other.iter()).all(|(e1, e2)| e1.eq(e2))
     }
 }
 
@@ -76,4 +73,3 @@ impl<'a> IntoIterator for &'a Cons {
         self.iter()
     }
 }
-

--- a/src/value/cons.rs
+++ b/src/value/cons.rs
@@ -11,6 +11,15 @@ pub struct Cons {
 
 unsafe impl Sync for Cons {}
 
+impl PartialEq for Cons {
+    fn eq(&self, other: &Self) -> bool {
+        self
+            .iter()
+            .zip(other.iter())
+            .all(|(e1, e2)| e1.eq(e2))
+    }
+}
+
 // TODO: to be TryFrom once rust stabilizes the trait
 impl TryInto<Cons> for Term {
     type Error = WrongBoxError;

--- a/src/value/cons.rs
+++ b/src/value/cons.rs
@@ -1,0 +1,68 @@
+use super::{Term, Variant, Header, WrongBoxError};
+use std::ptr::NonNull;
+use core::marker::PhantomData;
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct Cons {
+    pub head: Term,
+    pub tail: Term,
+}
+
+unsafe impl Sync for Cons {}
+
+// TODO: to be TryFrom once rust stabilizes the trait
+impl Cons {
+    #[inline]
+    fn try_from(value: &Term) -> Result<&mut Self, WrongBoxError> {
+        if let Variant::Cons(ptr) = value.into_variant() {
+            unsafe { return Ok(&mut *(ptr as *const Self)) }
+        }
+        Err(WrongBoxError)
+    }
+}
+
+pub struct Iter<'a> {
+    head: Option<NonNull<Cons>>,
+    //len: usize,
+    marker: PhantomData<&'a Cons>,
+}
+
+impl<'a> Iterator for Iter<'a> {
+    type Item = &'a Value;
+
+    #[inline]
+    fn next(&mut self) -> Option<&'a Value> {
+        self.head.map(|node| unsafe {
+            // Need an unbound lifetime to get 'a
+            let node = &*node.as_ptr();
+            if let Value::List(cons) = node.tail {
+                self.head = Some(NonNull::new_unchecked(cons as *mut Cons));
+            } else {
+                // TODO match badly formed lists
+                self.head = None;
+            }
+            &node.head
+        })
+    }
+}
+
+impl Cons {
+    pub fn iter(&self) -> Iter {
+        Iter {
+            head: unsafe { Some(NonNull::new_unchecked(self as *const Cons as *mut Cons)) },
+            //len: self.len,
+            marker: PhantomData,
+        }
+    }
+}
+
+impl<'a> IntoIterator for &'a Cons {
+    type Item = &'a Value;
+    type IntoIter = Iter<'a>;
+
+    fn into_iter(self) -> Iter<'a> {
+        self.iter()
+    }
+}
+

--- a/src/value/map.rs
+++ b/src/value/map.rs
@@ -9,7 +9,7 @@ pub type HAMT = HamtMap<Term, Term>;
 #[repr(C)]
 pub struct Map {
     pub header: Header,
-    pub value: HAMT,
+    pub map: HAMT,
 }
 
 // TODO: to be TryFrom once rust stabilizes the trait

--- a/src/value/map.rs
+++ b/src/value/map.rs
@@ -1,0 +1,54 @@
+use super::{Term, Variant, Header, WrongBoxError, BOXED_MAP};
+use hamt_rs::HamtMap;
+use std::cmp::Ordering;
+use std::hash::{Hash, Hasher};
+
+pub type HAMT = HamtMap<Term, Term>;
+
+#[derive(Eq, Clone)]
+#[repr(C)]
+pub struct Map {
+    pub header: Header,
+    pub map: HAMT,
+}
+
+// TODO: to be TryFrom once rust stabilizes the trait
+impl Map {
+    #[inline]
+    fn try_from(value: &Term) -> Result<&mut Self, WrongBoxError> {
+        if let Variant::Pointer(ptr) = value.into_variant() {
+            unsafe {
+                if *ptr == BOXED_MAP {
+                    return Ok(&mut *(ptr as *const Self))
+                }
+            }
+        }
+        Err(WrongBoxError)
+    }
+}
+
+impl Hash for Map {
+    fn hash<H: Hasher>(&self, _state: &mut H) {
+        unimplemented!()
+    }
+}
+
+impl PartialEq for Map {
+    fn eq(&self, _other: &Self) -> bool {
+        // Some(self.cmp(other))
+        unimplemented!()
+    }
+}
+
+impl PartialOrd for Map {
+    fn partial_cmp(&self, _other: &Self) -> Option<Ordering> {
+        // Some(self.cmp(other))
+        unimplemented!()
+    }
+}
+
+impl std::fmt::Debug for Map {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        write!(f, "#{{map}}")
+    }
+}

--- a/src/value/tuple.rs
+++ b/src/value/tuple.rs
@@ -1,0 +1,47 @@
+use super::{Term, Variant, Header, WrongBoxError, BOXED_TUPLE};
+use std::ops::{Deref, DerefMut};
+// use std::convert::TryFrom;
+
+#[derive(Debug)]
+#[repr(C)]
+pub struct Tuple {
+    /// Number of elements following the header.
+    pub header: Header,
+    pub len: u32,
+}
+
+const TUPLE_SIZE: usize = std::mem::size_of::<Tuple>();
+
+impl Tuple {
+    pub fn as_slice(&self) -> &[Term] {
+        &self[..]
+    }
+}
+
+impl Deref for Tuple {
+    type Target = [Term];
+    fn deref(&self) -> &[Term] {
+        unsafe { ::std::slice::from_raw_parts((self as *const Tuple).add(TUPLE_SIZE) as *const Term, self.len as usize) }
+    }
+}
+
+impl DerefMut for Tuple {
+    fn deref_mut(&mut self) -> &mut [Term] {
+        unsafe { ::std::slice::from_raw_parts_mut((self as *mut Tuple).add(TUPLE_SIZE) as *mut Term, self.len as usize) }
+    }
+}
+
+// TODO: to be TryFrom once rust stabilizes the trait
+impl Tuple {
+    #[inline]
+    fn try_from(value: &Term) -> Result<&mut Self, WrongBoxError> {
+        if let Variant::Pointer(ptr) = value.into_variant() {
+            unsafe {
+                if *ptr == BOXED_TUPLE {
+                    return Ok(&mut *(ptr as *const Self))
+                }
+            }
+        }
+        Err(WrongBoxError)
+    }
+}

--- a/src/value/tuple.rs
+++ b/src/value/tuple.rs
@@ -1,4 +1,4 @@
-use super::{Term, Variant, Header, WrongBoxError, BOXED_TUPLE, TryInto};
+use super::{Header, Term, TryInto, Variant, WrongBoxError, BOXED_TUPLE};
 use std::ops::{Deref, DerefMut};
 // use std::convert::TryFrom;
 
@@ -21,13 +21,23 @@ impl Tuple {
 impl Deref for Tuple {
     type Target = [Term];
     fn deref(&self) -> &[Term] {
-        unsafe { ::std::slice::from_raw_parts((self as *const Tuple).add(TUPLE_SIZE) as *const Term, self.len as usize) }
+        unsafe {
+            ::std::slice::from_raw_parts(
+                (self as *const Tuple).add(TUPLE_SIZE) as *const Term,
+                self.len as usize,
+            )
+        }
     }
 }
 
 impl DerefMut for Tuple {
     fn deref_mut(&mut self) -> &mut [Term] {
-        unsafe { ::std::slice::from_raw_parts_mut((self as *mut Tuple).add(TUPLE_SIZE) as *mut Term, self.len as usize) }
+        unsafe {
+            ::std::slice::from_raw_parts_mut(
+                (self as *mut Tuple).add(TUPLE_SIZE) as *mut Term,
+                self.len as usize,
+            )
+        }
     }
 }
 
@@ -46,7 +56,7 @@ impl TryInto<Tuple> for Term {
         if let Variant::Pointer(ptr) = self.into_variant() {
             unsafe {
                 if *ptr == BOXED_TUPLE {
-                    return Ok(&*(ptr as *const Tuple))
+                    return Ok(&*(ptr as *const Tuple));
                 }
             }
         }

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -942,7 +942,8 @@ impl Machine {
                 Opcode::GetList => {
                     // source, head, tail
                     if let Ok(value::Cons { head, tail }) =
-                        context.expand_arg(&ins.args[0]).clone().try_into() // TODO: this clone is bad but the borrow checker complains (but doesn't on GetTl/GetHd)
+                        context.expand_arg(&ins.args[0]).clone().try_into()
+                    // TODO: this clone is bad but the borrow checker complains (but doesn't on GetTl/GetHd)
                     {
                         set_register!(context, &ins.args[1], head.clone());
                         set_register!(context, &ins.args[2], tail.clone());
@@ -1450,7 +1451,9 @@ impl Machine {
                     // literal arity
                     let arity = ins.args[0].to_u32();
                     // TODO: this clone is bad but the borrow checker complains (but doesn't on GetTl/GetHd)
-                    if let Ok(value::Boxed { value, .. }) = context.x[arity as usize].clone().try_into() {
+                    if let Ok(value::Boxed { value, .. }) =
+                        context.x[arity as usize].clone().try_into()
+                    {
                         let closure: &value::Closure = value; // ughh type annotation
                         op_call_fun!(self, context, closure, arity)
                     } else {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -117,7 +117,7 @@ macro_rules! op_call_ext {
 
         println!(
             "call_ext mfa: {:?}, pid: {:?}",
-            (atom::from_index(mfa.0), atom::from_index(mfa.1), mfa.2),
+            (atom::to_str(mfa.0), atom::to_str(mfa.1), mfa.2),
             $process.pid
         );
 
@@ -532,7 +532,7 @@ impl Machine {
                 "running proc pid {:?} reds: {:?}, mod: {:?}, ins {:?}, args: {:?}",
                 process.pid,
                 reductions,
-                atom::from_index(module.name).unwrap(),
+                atom::to_str(module.name).unwrap(),
                 ins.op,
                 ins.args
             );
@@ -963,7 +963,7 @@ impl Machine {
                     let n = self.expand_arg(context, &ins.args[1]).to_u32();
                     if let Value::Tuple(t) = source {
                         let elem = unsafe {
-                            let slice: &[Value] = &(**t);
+                            let slice: &[Term] = &(**t);
                             slice[n as usize].clone()
                         };
                         set_register!(context, &ins.args[2], elem)
@@ -1001,7 +1001,7 @@ impl Machine {
                                 );
                             }
                         }
-                        set_register!(context, &ins.args[0], Value::Tuple(tuple))
+                        set_register!(context, &ins.args[0], Term::from(tuple))
                     }
                 }
                 Opcode::Badmatch => {

--- a/src/vm.rs
+++ b/src/vm.rs
@@ -196,11 +196,11 @@ macro_rules! op_apply_fun {
         let mut tmp = &$context.x[1];
         let mut arity = 0;
 
-        while let Term::List(ptr) = *tmp {
+        while let Ok(value::Cons { head, tail }) = tmp.try_into() {
             if arity < process::MAX_REG - 1 {
-                $context.x[arity] = unsafe { (*ptr).head.clone() };
+                $context.x[arity] = head.clone();
                 arity += 1;
-                tmp = unsafe { &(*ptr).tail }
+                tmp = tail
             } else {
                 return Err(Exception::new(Reason::EXC_SYSTEM_LIMIT));
             }


### PR DESCRIPTION
_Need to wrap this up over the weekend; got this drafted during my flights this week:_

Currently, our enums are 128-bit sized -- mainly because a regular pointer consumes 8 bytes, then the enum discriminant then consumes another 8 bytes (or 4 on 32 bit architectures) to be aligned. With [nanboxing](https://wingolog.org/archives/2011/05/18/value-representation-in-javascript-implementations), we can fit 8 values (well, float requires one bit + 7 extra values) into the NaN region, thus compressing values into 64 bits.

It's a distant relative to tagged pointers -- BEAM uses tagged pointers but uses a staged schema to be able to cram in more variants; since you can only safely tag the first two bits on 32 bit machines. NaN boxing has some tradeoffs on 32 bit processors, but since we're trying to stay simple, I think that's it's worthwhile to just favor 64 bit processors -- since we're abstracting the interface, we should be able to switch in the future without major changes to the code that's using the actual values.

Anyhow, compression makes the term structure a bit more complicated:

- Term represents a raw u64 value. It can be type checked directly, or unpacked into Variant to access the value.
- Variant is composed of immediate values (floats, integers, atoms, nil, etc.), or a boxed pointer, which points to a Value.
-  Value is a map, list, ref, anything that requires heap allocation and/or doesn't fit into an immediate value.

#### Ideas / things left to do

- Store the values uncompressed in the registers? V8 does that to enable certain optimizations, but that means we no longer can `memcpy` values in/out of the registers when we swap processes in/out of the executing thread -- we'd need to recompress the values.

- Can we use a combination of Box/Pin to provide access to the boxed data? Problem there would be that if we cast a term to a box, then the box goes out of scope, our inner value would drop, which is in most cases not what we want. (Rust 1.32 will ship today/tomorrow with ManuallyDrop, hmm).

- We either need to use an enum for the value, in which case we can just point to it; but will be wasteful since enums are sized as large as the largest enum variant; or we need the pointer to point to a header, followed by the data (as individual structs). To bind together the structs we could have an `impl Value` which would specify default implementations as well as the required traits (all values need to be Ord, Eq, Hash)

- Loader values were split off (as `LTerm`, will be renamed to `loader::Term`), and BEAM shares the general memory layout with runtime values so we can just re-cast the loader values without any copying. For the most part we don't need to do that, since instructions almost always use non-runtime values; the exception being atoms / integers.

- Implementation was taken from https://github.com/Marwes/nanbox, but I re-implemented the actual runtime values since the macro couldn't handle zero-sized types. Need to double check the implementation because I'd like to use nunboxing (favoring pointers over floats)